### PR TITLE
fix: Add GitHub PullRequest Labels

### DIFF
--- a/scm/driver/github/pr.go
+++ b/scm/driver/github/pr.go
@@ -63,6 +63,7 @@ type pr struct {
 	State              string      `json:"state"`
 	Title              string      `json:"title"`
 	Body               string      `json:"body"`
+	Labels             []*label    `json:"labels"`
 	DiffURL            string      `json:"diff_url"`
 	User               user        `json:"user"`
 	RequestedReviewers []user      `json:"requested_reviewers"`
@@ -101,6 +102,7 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 		Number:    from.Number,
 		Title:     from.Title,
 		Body:      from.Body,
+		Labels:    convertLabelObjects(from.Labels),
 		Sha:       from.Head.Sha,
 		Ref:       fmt.Sprintf("refs/pull/%d/head", from.Number),
 		State:     from.State,

--- a/scm/driver/github/testdata/pr.json
+++ b/scm/driver/github/testdata/pr.json
@@ -14,6 +14,17 @@
     "state": "open",
     "title": "new-feature",
     "body": "Please pull these awesome changes",
+    "labels": [
+      {
+        "id": 208045946,
+        "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
+        "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+        "name": "bug",
+        "description": "Something isn't working",
+        "color": "f29513",
+        "default": true
+      }
+    ],
     "assignee": {
         "login": "octocat",
         "id": 1,

--- a/scm/driver/github/testdata/pr.json.golden
+++ b/scm/driver/github/testdata/pr.json.golden
@@ -2,6 +2,14 @@
   "Number": 1347,
   "Title": "new-feature",
   "Body": "Please pull these awesome changes",
+  "Labels": [
+    {
+      "Url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
+      "Name": "bug",
+      "Description": "Something isn't working",
+      "Color": "f29513"
+    }
+  ],
   "Sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
   "Ref": "refs/pull/1347/head",
   "Source": "new-topic",

--- a/scm/driver/github/testdata/webhooks/pr_labeled.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_labeled.json.golden
@@ -22,6 +22,13 @@
     "Number": 1,
     "Title": "Update .drone.yml",
     "Body": "",
+    "Labels": [
+      {
+        "Name": "bug",
+        "Color": "fc2929",
+        "URL": "https://api.github.com/repos/bradrydzewski/drone-test-go/labels/bug"
+      }
+    ],
     "Sha": "d2b75aa7797ec26b088fa2dd527e9d2c052fcedd",
     "Ref": "refs/pull/1/head",
     "Source": "master",

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -15,6 +15,7 @@ type (
 		Number    int
 		Title     string
 		Body      string
+		Labels    []*Label
 		Sha       string
 		Ref       string
 		Source    string


### PR DESCRIPTION
Adds labels to PullRequest for the GitHub driver for #21 

Does not include an integration test, since no PR in the example repo or the drone/go-scm repo have a sample labelled PR (AFAICT anyway).