### PR TITLE
fix: fix use of branch/ref and sha in PullRequestHook

### DIFF
--- a/scm/driver/gitlab/testdata/webhooks/pull_request_close.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_close.json.golden
@@ -20,7 +20,7 @@
     "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",
     "Ref": "refs/merge-requests/1/head",
     "Base": {
-      "Ref": "refs/merge-requests/1/head",
+      "Ref": "master",
       "Repo": {
         "ID": "4861503",
         "Namespace": "gitlab-org",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_create.json.golden
@@ -20,7 +20,7 @@
     "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",
     "Ref": "refs/merge-requests/1/head",
     "Base": {
-      "Ref": "refs/merge-requests/1/head",
+      "Ref": "master",
       "Repo": {
         "ID": "4861503",
         "Namespace": "gitlab-org",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_merge.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_merge.json.golden
@@ -20,7 +20,7 @@
     "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",
     "Ref": "refs/merge-requests/1/head",
     "Base": {
-      "Ref": "refs/merge-requests/1/head",
+      "Ref": "master",
       "Repo": {
         "ID": "4861503",
         "Namespace": "gitlab-org",

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json.golden
@@ -20,7 +20,7 @@
     "Sha": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",
     "Ref": "refs/merge-requests/1/head",
     "Base": {
-      "Ref": "refs/merge-requests/1/head",
+      "Ref": "master",
       "Repo": {
         "ID": "4861503",
         "Namespace": "gitlab-org",

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -257,7 +257,7 @@ func convertPullRequestHook(src *pullRequestHook) *scm.PullRequestHook {
 		Sha:    sha,
 		Ref:    ref,
 		Base: scm.PullRequestBranch{
-			Ref: ref,
+			Ref: repo.Branch,
 		},
 		Head: scm.PullRequestBranch{
 			Sha: sha,

--- a/scm/driver/stash/pr.go
+++ b/scm/driver/stash/pr.go
@@ -184,7 +184,7 @@ func convertPullRequest(from *pullRequest) *scm.PullRequest {
 		Target: from.ToRef.DisplayID,
 		Fork:   fork,
 		Base: scm.PullRequestBranch{
-			Ref: from.FromRef.LatestCommit,
+			Sha: from.FromRef.LatestCommit,
 		},
 		Head: scm.PullRequestBranch{
 			Sha: from.FromRef.LatestCommit,

--- a/scm/driver/stash/testdata/pr.json.golden
+++ b/scm/driver/stash/testdata/pr.json.golden
@@ -7,9 +7,11 @@
   "Source": "feature/x",
   "Target": "master",
   "Base": {
-    "Ref": "131cb13f4aed12e725177bc4b7c28db67839bf9f"
+    "Ref": "",
+    "Sha": "131cb13f4aed12e725177bc4b7c28db67839bf9f"
   },
   "Head": {
+    "Ref": "",
     "Sha": "131cb13f4aed12e725177bc4b7c28db67839bf9f"
   },
   "Fork": "PRJ/my-repo",

--- a/scm/driver/stash/testdata/prs.json.golden
+++ b/scm/driver/stash/testdata/prs.json.golden
@@ -8,7 +8,7 @@
     "Source": "feature/x",
     "Target": "master",
     "Base": {
-      "Ref": "131cb13f4aed12e725177bc4b7c28db67839bf9f"
+      "Sha": "131cb13f4aed12e725177bc4b7c28db67839bf9f"
     },
     "Head": {
       "Sha": "131cb13f4aed12e725177bc4b7c28db67839bf9f"

--- a/scm/driver/stash/testdata/webhooks/pr_comment.json.golden
+++ b/scm/driver/stash/testdata/webhooks/pr_comment.json.golden
@@ -23,8 +23,8 @@
     "Source": "comment-pr",
     "Target": "master",
     "Base": {
-      "Ref": "ddc19f786996396d57e17c8f6d1d05d00318ad10",
-      "Sha": "",
+      "Ref": "",
+      "Sha": "ddc19f786996396d57e17c8f6d1d05d00318ad10",
       "Repo": {
         "ID": "84",
         "Namespace": "PROJ",

--- a/scm/driver/stash/testdata/webhooks/pr_declined.json.golden
+++ b/scm/driver/stash/testdata/webhooks/pr_declined.json.golden
@@ -27,7 +27,8 @@
     "Merged": false,
     "State": "declined",
     "Base": {
-      "Ref": "b9eaed50a03c073b20dfa82e5e753d295e7f0e56",
+      "Ref": "master",
+      "Sha": "b9eaed50a03c073b20dfa82e5e753d295e7f0e56",
       "Repo": {
         "ID": "1",
         "Namespace": "PRJ",
@@ -43,6 +44,7 @@
       }
     },
     "Head": {
+      "Ref": "master",
       "Sha": "b9eaed50a03c073b20dfa82e5e753d295e7f0e56",
       "Repo": {
         "ID": "1",

--- a/scm/driver/stash/testdata/webhooks/pr_merged.json.golden
+++ b/scm/driver/stash/testdata/webhooks/pr_merged.json.golden
@@ -27,7 +27,8 @@
     "Merged": true,
     "State": "merged",
     "Base": {
-      "Ref": "b9eaed50a03c073b20dfa82e5e753d295e7f0e56",
+      "Ref": "master",
+      "Sha": "b9eaed50a03c073b20dfa82e5e753d295e7f0e56",
       "Repo": {
         "ID": "1",
         "Namespace": "PRJ",
@@ -43,6 +44,7 @@
       }
     },
     "Head": {
+      "Ref": "master",
       "Sha": "b9eaed50a03c073b20dfa82e5e753d295e7f0e56",
       "Repo": {
         "ID": "1",

--- a/scm/driver/stash/testdata/webhooks/pr_open.json.golden
+++ b/scm/driver/stash/testdata/webhooks/pr_open.json.golden
@@ -27,7 +27,8 @@
     "Merged": false,
     "State": "open",
     "Base": {
-      "Ref": "208b0a5c05eddadad01f2aed8802fe0c3b3eaf5e",
+      "Ref": "master",
+      "Sha": "208b0a5c05eddadad01f2aed8802fe0c3b3eaf5e",
       "Repo": {
         "ID": "1",
         "Namespace": "PRJ",
@@ -43,6 +44,7 @@
       }
     },
     "Head": {
+      "Ref": "master",
       "Sha": "208b0a5c05eddadad01f2aed8802fe0c3b3eaf5e",
       "Repo": {
         "ID": "1",

--- a/scm/driver/stash/webhook.go
+++ b/scm/driver/stash/webhook.go
@@ -253,6 +253,12 @@ func convertPullRequestHook(src *pullRequestHook) *scm.PullRequestHook {
 	sender := convertUser(src.Actor)
 	pr.Base.Repo = *repo
 	pr.Head.Repo = *repo
+	if pr.Base.Ref == "" {
+		pr.Base.Ref = repo.Branch
+	}
+	if pr.Head.Ref == "" {
+		pr.Head.Ref = repo.Branch
+	}
 	return &scm.PullRequestHook{
 		Action:      scm.ActionOpen,
 		Repo:        *repo,


### PR DESCRIPTION
we were populating PullRequestHook.Base.Ref with the sha and not populating the ref/branch for stash + gitlab