### PR TITLE
WIP feat: add support for deserializing Webhooks into concrete types.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
-	github.com/sirupsen/logrus v1.4.2 // indirect
+	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	k8s.io/apimachinery v0.0.0-20190703205208-4cfb76a8bf76

--- a/scm/webhook_test.go
+++ b/scm/webhook_test.go
@@ -1,0 +1,39 @@
+package scm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSerialization(t *testing.T) {
+	pushHookUnMarshaler := &WebhookSerializer{
+		Webhook: &PushHook{
+			Ref:     "789def",
+			BaseRef: "123abc",
+			Repo: Repository{
+				Name: "test-repo",
+			},
+			Created: true,
+			Deleted: false,
+			Forced:  false,
+			GUID:    "test-repo",
+		},
+	}
+
+	marshaledPushHook, err := json.Marshal(pushHookUnMarshaler)
+	assert.NoError(t, err)
+	assert.NotNil(t, marshaledPushHook)
+
+	var unmarshaledHook WebhookSerializer
+	err = json.Unmarshal(marshaledPushHook, &unmarshaledHook)
+	assert.NoError(t, err)
+	assert.NotNil(t, unmarshaledHook)
+	t.Logf("%v", unmarshaledHook)
+
+	unmarshaledPushHook, ok := unmarshaledHook.Webhook.(*PushHook)
+	assert.True(t, ok)
+	assert.NotNil(t, unmarshaledPushHook)
+
+}


### PR DESCRIPTION
This prevents errors during deserialization that result in the serialized Webhook being rendered into a generic `map[string]interface{}` instead of a concrete type (e.g., `DeployHook`, `TagHook`, etc).