### PR TITLE
fix: github enterprise graphql endpoint url

### DIFF
--- a/scm/client.go
+++ b/scm/client.go
@@ -89,7 +89,8 @@ type (
 		Client *http.Client
 
 		// Base URL for API requests.
-		BaseURL *url.URL
+		BaseURL    *url.URL
+		GraphQLURL *url.URL
 
 		// Services used for communicating with the API.
 		Driver        Driver

--- a/scm/driver/github/github.go
+++ b/scm/driver/github/github.go
@@ -49,6 +49,13 @@ func New(uri string) (*scm.Client, error) {
 	client.Webhooks = &webhookService{client}
 
 	graphqlEndpoint := scm.UrlJoin(uri, "/graphql")
+	if strings.HasSuffix(uri, "/api/v3") {
+		graphqlEndpoint = scm.UrlJoin(uri[0:len(uri)-2], "graphql")
+	}
+	client.GraphQLURL, err = url.Parse(graphqlEndpoint)
+	if err != nil {
+		return nil, err
+	}
 	client.GraphQL = &dynamicGraphQLClient{client, graphqlEndpoint}
 
 	return client.Client, nil

--- a/scm/driver/github/github_test.go
+++ b/scm/driver/github/github_test.go
@@ -34,6 +34,16 @@ func TestClient(t *testing.T) {
 	}
 }
 
+func TestGraphQLClient(t *testing.T) {
+	client, err := New("https://api.github.com")
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := client.GraphQLURL.String(), "https://api.github.com/graphql"; got != want {
+		t.Errorf("Want GraphQl Client URL %q, got %q", want, got)
+	}
+}
+
 func TestClient_Base(t *testing.T) {
 	client, err := New("https://github.example.com/api/v3")
 	if err != nil {
@@ -41,6 +51,16 @@ func TestClient_Base(t *testing.T) {
 	}
 	if got, want := client.BaseURL.String(), "https://github.example.com/api/v3/"; got != want {
 		t.Errorf("Want Client URL %q, got %q", want, got)
+	}
+}
+
+func TestEnterpriseGraphQLClient(t *testing.T) {
+	client, err := New("https://github.example.com/api/v3")
+	if err != nil {
+		t.Error(err)
+	}
+	if got, want := client.GraphQLURL.String(), "https://github.example.com/api/graphql"; got != want {
+		t.Errorf("Want GraphQl Client URL %q, got %q", want, got)
 	}
 }
 


### PR DESCRIPTION
Exposes Client.GraphQLURL to enable testing.

fixes #31