### PR TITLE
fix; Add JSON marshalling support for State codes.

### DIFF
--- a/scm/const.go
+++ b/scm/const.go
@@ -70,6 +70,15 @@ func ToState(s string) State {
 	}
 }
 
+func (s State) MarshalJSON() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s *State) UnmarshalJSON(b []byte) error {
+	*s = ToState(strings.Trim(string(b), `"`))
+	return nil
+}
+
 // Action identifies webhook actions.
 type Action int
 

--- a/scm/driver/bitbucket/testdata/status.json.golden
+++ b/scm/driver/bitbucket/testdata/status.json.golden
@@ -1,5 +1,5 @@
 {
-    "State": 3,
+    "State": "success",
     "Label": "drone",
     "Desc": "Build has completed successfully",
     "Target": "https://ci.example.com/1000/output"

--- a/scm/driver/bitbucket/testdata/statuses.json.golden
+++ b/scm/driver/bitbucket/testdata/statuses.json.golden
@@ -1,6 +1,6 @@
 [
     {
-        "State": 3,
+        "State": "success",
         "Label": "drone",
         "Desc": "Build has completed successfully",
         "Target": "https://ci.example.com/1000/output"

--- a/scm/driver/gitea/testdata/status.json.golden
+++ b/scm/driver/gitea/testdata/status.json.golden
@@ -1,5 +1,5 @@
 {
-    "State": 3,
+    "State": "success",
     "Label": "continuous-integration/drone",
     "Desc": "",
     "Target": "https://example.com"

--- a/scm/driver/gitea/testdata/statuses.json.golden
+++ b/scm/driver/gitea/testdata/statuses.json.golden
@@ -1,6 +1,6 @@
 [
     {
-        "State": 3,
+        "State": "success",
         "Label": "continuous-integration/drone",
         "Desc": "",
         "Target": "https://example.com"

--- a/scm/driver/github/testdata/combined_status.json.golden
+++ b/scm/driver/github/testdata/combined_status.json.golden
@@ -1,15 +1,15 @@
 {
-    "State": 3,
+    "State": "success",
     "Sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
     "Statuses": [
         {
-            "State": 3,
+            "State": "success",
             "Label": "continuous-integration/jenkins",
             "Desc": "Build has completed successfully",
             "Target": "https://ci.example.com/1000/output"
         },
         {
-            "State": 3,
+            "State": "success",
             "Label": "security/brakeman",
             "Desc": "Testing has completed successfully",
             "Target": "https://ci.example.com/2000/output"

--- a/scm/driver/github/testdata/status.json.golden
+++ b/scm/driver/github/testdata/status.json.golden
@@ -1,5 +1,5 @@
 {
-    "State": 3,
+    "State": "success",
     "Label": "continuous-integration/drone",
     "Desc": "Build has completed successfully",
     "Target": "https://ci.example.com/1000/output"

--- a/scm/driver/github/testdata/statuses.json.golden
+++ b/scm/driver/github/testdata/statuses.json.golden
@@ -1,6 +1,6 @@
 [
     {
-        "State": 3,
+        "State": "success",
         "Label": "continuous-integration/drone",
         "Desc": "Build has completed successfully",
         "Target": "https://ci.example.com/1000/output"

--- a/scm/driver/gitlab/testdata/status.json.golden
+++ b/scm/driver/gitlab/testdata/status.json.golden
@@ -1,5 +1,5 @@
 {
-    "State": 1,
+    "State": "pending",
     "Label": "default",
     "Desc": "the dude abides",
     "Target": "https://gitlab.example.com/thedude/gitlab-ce/builds/91"

--- a/scm/driver/gitlab/testdata/statuses.json.golden
+++ b/scm/driver/gitlab/testdata/statuses.json.golden
@@ -1,6 +1,6 @@
 [
     {
-        "State": 1,
+        "State": "pending",
         "Label": "default",
         "Desc": "the dude abides",
         "Target": "https://gitlab.example.com/thedude/gitlab-ce/builds/91"

--- a/scm/driver/stash/testdata/commit_build_status.json.golden
+++ b/scm/driver/stash/testdata/commit_build_status.json.golden
@@ -1,12 +1,12 @@
 [
   {
-    "State": 3,
+    "State": "success",
     "Label": "team-bb-server » repo-1 » master #23",
     "Desc": "This commit looks good.",
     "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/21/display/redirect"
   },
   {
-    "State": 3,
+    "State": "success",
     "Label": "team-bb-server » repo-1 » master #22",
     "Desc": "This commit looks good.",
     "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22/display/redirect"


### PR DESCRIPTION
This converts JSON serialization of statuses into their string
representation. e.g.

Old:
```
{
  "state": 3,
}
```

New:
```
{
  "state": "success",
}
```