### PR TITLE
fix: json.Marshal for State.

### DIFF
--- a/scm/const.go
+++ b/scm/const.go
@@ -6,6 +6,7 @@ package scm
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 )
 
@@ -71,7 +72,7 @@ func ToState(s string) State {
 }
 
 func (s State) MarshalJSON() ([]byte, error) {
-	return []byte(s.String()), nil
+	return []byte(fmt.Sprintf(`"%s"`, s.String())), nil
 }
 
 func (s *State) UnmarshalJSON(b []byte) error {

--- a/scm/const_test.go
+++ b/scm/const_test.go
@@ -1,0 +1,27 @@
+package scm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestStateJSON(t *testing.T) {
+	for i := StateUnknown; i < StateExpected; i++ {
+		in := State(i)
+		t.Run(in.String(), func(t *testing.T) {
+			b, err := json.Marshal(in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var out State
+			if err := json.Unmarshal(b, &out); err != nil {
+				t.Fatal(err)
+			}
+
+			if in != out {
+				t.Errorf("%s != %s", in, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes breakage when using json.Marshal introduced in
fad5b44456ec8ba9c04161449d8ca37ab1a37ae9.

Not entirely sure why the other tests in the previous commit succeeded, so also
makes sure this is tested explicitly.