### PR TITLE
fix: filter statuses in the github driver

### DIFF
--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -359,9 +359,19 @@ func convertCombinedStatus(from *combinedStatus) *scm.CombinedStatus {
 }
 
 func convertStatusList(from []*status) []*scm.Status {
+	// The GitHub API may return multiple statuses with the same Context, in
+	// reverse chronological order:
+	// https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref.
+	// We only expose the most recent one to consumers.
 	to := []*scm.Status{}
+	unique := make(map[string]interface{})
 	for _, v := range from {
-		to = append(to, convertStatus(v))
+		convertedStatus := convertStatus(v)
+		if _, ok := unique[convertedStatus.Label]; ok {
+			continue
+		}
+		to = append(to, convertedStatus)
+		unique[convertedStatus.Label] = nil
 	}
 	return to
 }

--- a/scm/driver/github/testdata/statuses.json
+++ b/scm/driver/github/testdata/statuses.json
@@ -27,5 +27,34 @@
             "type": "User",
             "site_admin": false
         }
+    },
+    {
+        "created_at": "2012-06-20T01:19:13Z",
+        "updated_at": "2012-06-20T01:19:13Z",
+        "state": "failure",
+        "target_url": "https://ci.example.com/1000/output",
+        "description": "Build failed",
+        "id": 2,
+        "url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        "context": "continuous-integration/drone",
+        "creator": {
+            "login": "octocat",
+            "id": 1,
+            "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/octocat",
+            "html_url": "https://github.com/octocat",
+            "followers_url": "https://api.github.com/users/octocat/followers",
+            "following_url": "https://api.github.com/users/octocat/following{/other_user}",
+            "gists_url": "https://api.github.com/users/octocat/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/octocat/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/octocat/subscriptions",
+            "organizations_url": "https://api.github.com/users/octocat/orgs",
+            "repos_url": "https://api.github.com/users/octocat/repos",
+            "events_url": "https://api.github.com/users/octocat/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/octocat/received_events",
+            "type": "User",
+            "site_admin": false
+        }
     }
 ]


### PR DESCRIPTION
GitHub keeps multiple versions of a check with the same label.
The API returns the list in reverse chronological order:
https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref.

The status resource in go-scm does not expose any information
that might help distinguish between versions of checks with
the same label.

When a client of go-scm receives a list of statuses that contain
duplicate labels, it has no way of finding out which one is the
most recent one.

Change the github driver to filter the statuses and only return
one (the most recent) for each label.

Fixes #79