### PR TITLE
feat: Paginate Fake driver PullRequest ListChanges

### DIFF
--- a/scm/driver/fake/pr.go
+++ b/scm/driver/fake/pr.go
@@ -36,7 +36,8 @@ func (s *pullService) List(context.Context, string, scm.PullRequestListOptions) 
 
 func (s *pullService) ListChanges(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	f := s.data
-	return f.PullRequestChanges[number], nil, nil
+	returnStart, returnEnd := paginated(opts.Page, opts.Size, len(f.PullRequestChanges[number]))
+	return f.PullRequestChanges[number][returnStart:returnEnd], nil, nil
 }
 
 func (s *pullService) ListComments(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {

--- a/scm/driver/fake/pr_test.go
+++ b/scm/driver/fake/pr_test.go
@@ -1,0 +1,83 @@
+package fake
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/jenkins-x/go-scm/scm"
+)
+
+func TestListChangesPagination(t *testing.T) {
+	prNum := 11
+	pageTests := []struct {
+		prNum     int
+		items     int
+		page      int
+		size      int
+		wantFiles []string
+	}{
+		{prNum, 10, 2, 5, []string{"file6", "file7", "file8", "file9", "file10"}},
+		{50, 10, 2, 5, []string{}},
+	}
+
+	for i, tt := range pageTests {
+		t.Run(fmt.Sprintf("[%d]", i+1), func(rt *testing.T) {
+			ctx := context.Background()
+			client, data := NewDefault()
+			// This stores the data in the "prNum" PR, but the list gets it from
+			// the test number.
+			data.PullRequestChanges[prNum] = makeChanges(tt.items)
+
+			items, _, err := client.PullRequests.ListChanges(ctx, "test/test", tt.prNum, scm.ListOptions{Page: tt.page, Size: tt.size})
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if got := extractChangeFiles(items); !reflect.DeepEqual(got, tt.wantFiles) {
+				rt.Errorf("ListChanges() got %#v, want %#v", got, tt.wantFiles)
+			}
+		})
+	}
+}
+
+func TestPaginated(t *testing.T) {
+	tests := []struct {
+		page      int
+		size      int
+		items     int
+		wantStart int
+		wantEnd   int
+	}{
+		{1, 5, 10, 0, 5},
+		{2, 5, 10, 5, 10},
+		{2, 5, 9, 5, 9},
+		{4, 5, 10, 10, 10}, // this results in an empty slice
+	}
+
+	for _, tt := range tests {
+		start, end := paginated(tt.page, tt.size, tt.items)
+		if tt.wantStart != start || tt.wantEnd != end {
+			t.Fatalf("paginaged(%d, %d, %d) got items[%d:%d], want items[%d:%d]", tt.page, tt.size, tt.items, start, end, tt.wantStart, tt.wantEnd)
+		}
+	}
+}
+
+func makeChanges(n int) []*scm.Change {
+	c := []*scm.Change{}
+	for i := 1; i <= n; i++ {
+		c = append(c, &scm.Change{
+			Path: fmt.Sprintf("file%d", i),
+		})
+	}
+	return c
+}
+
+func extractChangeFiles(ch []*scm.Change) []string {
+	f := []string{}
+	for _, c := range ch {
+		f = append(f, c.Path)
+	}
+	return f
+}

--- a/scm/driver/fake/utils.go
+++ b/scm/driver/fake/utils.go
@@ -1,0 +1,13 @@
+package fake
+
+func paginated(page, size, items int) (start, end int) {
+	start = (page - 1) * size
+	if start > items {
+		start = items
+	}
+	end = start + size
+	if end > items {
+		end = items
+	}
+	return
+}


### PR DESCRIPTION
This implements pagination of the ListChanges (using the ListOption settings) of the fake driver's `ListChanges` for PullRequests.

This calculates the start/end of the slice to return based on the data, and returns.

This pagination function is reusable in other fake methods.