### PR TITLE
feat: include member repo creation perms in org

### DIFF
--- a/scm/org.go
+++ b/scm/org.go
@@ -11,10 +11,16 @@ import (
 type (
 	// Organization represents an organization account.
 	Organization struct {
-		Name   string
-		Avatar string
+		Name        string
+		Avatar      string
+		Permissions Permissions
 	}
 
+	Permissions struct {
+		MembersCreatePrivate  bool
+		MembersCreatePublic   bool
+		MembersCreateInternal bool
+	}
 	// Team is a organizational team
 	Team struct {
 		ID          int


### PR DESCRIPTION
I'm not sure how to test this as it only works on orgs that the user belongs to.

I've manually fudged the test to make it work (but reverted before i made this PR)