### PR TITLE
fix: If we have no default page or other options, respond with all items.

### DIFF
--- a/scm/driver/fake/pr_test.go
+++ b/scm/driver/fake/pr_test.go
@@ -54,6 +54,7 @@ func TestPaginated(t *testing.T) {
 		{2, 5, 10, 5, 10},
 		{2, 5, 9, 5, 9},
 		{4, 5, 10, 10, 10}, // this results in an empty slice
+		{0, 0, 10, 0, 10},  // this is the default 0 value for ListOption
 	}
 
 	for _, tt := range tests {

--- a/scm/driver/fake/utils.go
+++ b/scm/driver/fake/utils.go
@@ -1,6 +1,13 @@
 package fake
 
 func paginated(page, size, items int) (start, end int) {
+	// handle the default value case for ListOptions.
+	if page == 0 && size == 0 {
+		start = 0
+		end = items
+		return
+	}
+
 	start = (page - 1) * size
 	if start > items {
 		start = items


### PR DESCRIPTION
This updates the pagination to return all items if there's no size or page.