### PR TITLE
fix: github org's permissions

### DIFF
--- a/scm/driver/github/org.go
+++ b/scm/driver/github/org.go
@@ -16,7 +16,10 @@ import (
 type organizationService struct {
 	client *wrapper
 }
-
+type plan struct {
+	Name                 string `json:"name"`
+	PrivateRepos   int   `json:"private_repos"`
+}
 type organization struct {
 	ID                    int    `json:"id,omitempty"`
 	Login                 string `json:"login"`
@@ -24,6 +27,7 @@ type organization struct {
 	MembersCreatePublic   bool   `json:"members_can_create_public_repositories"`
 	MembersCreatePrivate  bool   `json:"members_can_create_private_repositories"`
 	MembersCreateInternal bool   `json:"members_can_create_internal_repositories"`
+	Plan                  plan
 }
 
 type team struct {
@@ -123,7 +127,9 @@ func convertOrganization(from *organization) *scm.Organization {
 		Permissions: scm.Permissions{
 			MembersCreateInternal: from.MembersCreateInternal,
 			MembersCreatePublic:   from.MembersCreatePublic,
-			MembersCreatePrivate:  from.MembersCreatePrivate,
+			// GH API can return true for from.MembersCreatePrivate but if the org's plan is free, the max number of
+			// private repo is 0. Let's check the members can create private repos AND the org can have private repos.
+			MembersCreatePrivate:  from.MembersCreatePrivate && from.Plan.PrivateRepos > 0,
 		},
 	}
 }

--- a/scm/driver/github/testdata/org.json
+++ b/scm/driver/github/testdata/org.json
@@ -28,11 +28,13 @@
     "disk_usage": 10000,
     "collaborators": 8,
     "billing_email": "support@github.com",
+    "members_can_create_public_repositories": true,
+    "members_can_create_private_repositories": true,
+    "members_can_create_internal_repositories": true,
     "plan": {
         "name": "Medium",
         "space": 400,
         "private_repos": 20
     },
-    "default_repository_settings": "read",
-    "members_can_create_repositories": true
+    "default_repository_settings": "read"
 }

--- a/scm/driver/github/testdata/org.json.golden
+++ b/scm/driver/github/testdata/org.json.golden
@@ -1,5 +1,10 @@
 {
     "ID": 1,
     "Name": "github",
-    "Avatar": "https://github.com/images/error/octocat_happy.gif"
+    "Avatar": "https://github.com/images/error/octocat_happy.gif",
+    "Permissions": {
+        "MembersCreatePrivate": true,
+        "MembersCreatePublic": true,
+        "MembersCreateInternal": true
+    }
 }


### PR DESCRIPTION
Follow-up on PR https://github.com/jenkins-x/go-scm/pull/82 this PR make sure members can create private repos for a given org.
This is needed for https://github.com/cloudbees/jxui-frontend/issues/1295