### PR TITLE
feat: Add support for factory options.

### DIFF
--- a/scm/factory/factory.go
+++ b/scm/factory/factory.go
@@ -22,8 +22,10 @@ import (
 // MissingGitServerURL the error returned if you use a git driver that needs a git server URL
 var MissingGitServerURL = fmt.Errorf("No git serverURL was specified")
 
+type clientOptionFunc func(*scm.Client)
+
 // NewClient creates a new client for a given driver, serverURL and OAuth token
-func NewClient(driver, serverURL, oauthToken string) (*scm.Client, error) {
+func NewClient(driver, serverURL, oauthToken string, opts ...clientOptionFunc) (*scm.Client, error) {
 	if driver == "" {
 		driver = "github"
 	}
@@ -86,6 +88,9 @@ func NewClient(driver, serverURL, oauthToken string) (*scm.Client, error) {
 			client.Client = oauth2.NewClient(context.Background(), ts)
 		}
 	}
+	for _, o := range opts {
+		o(client)
+	}
 	return client, err
 }
 
@@ -124,4 +129,10 @@ func ensureBBCEndpoint(u string) string {
 		return "https://api.bitbucket.org"
 	}
 	return u
+}
+
+func Client(httpClient *http.Client) clientOptionFunc {
+	return func(c *scm.Client) {
+		c.Client = httpClient
+	}
 }

--- a/scm/factory/factory_test.go
+++ b/scm/factory/factory_test.go
@@ -1,6 +1,7 @@
 package factory
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ func TestNewClient(t *testing.T) {
 		t.Errorf("no client created")
 	}
 	if err != nil {
-		t.Errorf("failed to create client %s", err.Error())
+		t.Errorf("failed to create client %s", err)
 	}
 }
 
@@ -20,4 +21,14 @@ func TestGHEEndpoint(t *testing.T) {
 	assert.Equal(t, "https://my.ghe.com/custom/api/v5", ensureGHEEndpoint("https://my.ghe.com/custom/api/v5"))
 	assert.Equal(t, "https://my.ghe.com/custom/api/v3", ensureGHEEndpoint("https://my.ghe.com/custom"))
 	assert.Equal(t, "https://my.ghe.com/api/v3", ensureGHEEndpoint("https://my.ghe.com"))
+}
+
+func TestNewClientWithOptionFunc(t *testing.T) {
+	httpClient := &http.Client{}
+	scmClient, err := NewClient("github", "", "", Client(httpClient))
+	if err != nil {
+		t.Errorf("failed to create client %s", err)
+	}
+
+	assert.Equal(t, scmClient.Client, httpClient)
 }


### PR DESCRIPTION
This adds support for client option functions to be passed when creating a new
scm.Client using the factory function.

A single option func is provided 'factory.Client' which allows injection of a
custom HTTP client at construction time.