### PR TITLE
chore: Add a bunch of GitLab API functionality

### DIFF
--- a/scm/const.go
+++ b/scm/const.go
@@ -16,13 +16,13 @@ type State int
 // State values.
 const (
 	StateUnknown State = iota
-	StatePending
-	StateRunning
-	StateSuccess
 	StateFailure
 	StateCanceled
 	StateError
 	StateExpected
+	StatePending
+	StateRunning
+	StateSuccess
 )
 
 // String returns a string representation of the State

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -52,7 +52,7 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 }
 
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Reference, *scm.Response, error) {

--- a/scm/driver/bitbucket/issue.go
+++ b/scm/driver/bitbucket/issue.go
@@ -15,86 +15,69 @@ type issueService struct {
 }
 
 func (s *issueService) Search(context.Context, scm.SearchOptions) ([]*scm.SearchIssue, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListLabels(context.Context, string, int, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) DeleteLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) Find(ctx context.Context, repo string, number int) (*scm.Issue, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) FindComment(ctx context.Context, repo string, index, id int) (*scm.Comment, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) List(ctx context.Context, repo string, opts scm.IssueListOptions) ([]*scm.Issue, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListComments(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) Create(ctx context.Context, repo string, input *scm.IssueInput) (*scm.Issue, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) CreateComment(ctx context.Context, repo string, number int, input *scm.CommentInput) (*scm.Comment, *scm.Response, error) {
-	// TODO implement
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) DeleteComment(ctx context.Context, repo string, number, id int) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) Close(ctx context.Context, repo string, number int) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) Lock(ctx context.Context, repo string, number int) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) Unlock(ctx context.Context, repo string, number int) (*scm.Response, error) {
-	// TODO implement
-	return nil, nil
+	return nil, scm.ErrNotSupported
 }

--- a/scm/driver/bitbucket/org.go
+++ b/scm/driver/bitbucket/org.go
@@ -16,15 +16,15 @@ type organizationService struct {
 }
 
 func (s *organizationService) IsMember(ctx context.Context, org string, user string) (bool, *scm.Response, error) {
-	panic("implement me")
+	return false, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) ListTeams(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organization, *scm.Response, error) {

--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -53,6 +53,10 @@ func (s *pullService) ListLabels(context.Context, string, int, scm.ListOptions) 
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *pullService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *pullService) DeleteLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }
@@ -64,6 +68,14 @@ func (s *pullService) Merge(ctx context.Context, repo string, number int) (*scm.
 }
 
 func (s *pullService) Close(ctx context.Context, repo string, number int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }
 

--- a/scm/driver/bitbucket/repo.go
+++ b/scm/driver/bitbucket/repo.go
@@ -60,27 +60,27 @@ type repositoryService struct {
 }
 
 func (s *repositoryService) Create(context.Context, *scm.RepositoryInput) (*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref string) (*scm.CombinedStatus, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindUserPermission(ctx context.Context, repo string, user string) (string, *scm.Response, error) {
-	panic("implement me")
+	return "", nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {
-	panic("implement me")
+	return false, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListCollaborators(ctx context.Context, repo string) ([]scm.User, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListLabels(context.Context, string, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 // Find returns the repository by name.
@@ -120,11 +120,11 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 }
 
 func (s *repositoryService) ListOrganisation(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListUser(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 // ListHooks returns a list or repository hooks.

--- a/scm/driver/fake/pr.go
+++ b/scm/driver/fake/pr.go
@@ -61,6 +61,10 @@ func (s *pullService) ListLabels(ctx context.Context, repo string, number int, o
 	return la, nil, nil
 }
 
+func (s *pullService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *pullService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
 	f := s.data
 	labelString := fmt.Sprintf("%s#%d:%s", repo, number, label)
@@ -124,6 +128,14 @@ func (s *pullService) DeleteComment(ctx context.Context, repo string, number int
 		}
 	}
 	return nil, fmt.Errorf("could not find issue comment %d", id)
+}
+
+func (s *pullService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
+	panic("implement me")
+}
+
+func (s *pullService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
+	panic("implement me")
 }
 
 func (s *pullService) Create(ctx context.Context, repo string, input *scm.PullRequestInput) (*scm.PullRequest, *scm.Response, error) {

--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -17,11 +17,11 @@ type gitService struct {
 }
 
 func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *scm.Response, error) {
-	panic("implement me")
+	return "", nil, scm.ErrNotSupported
 }
 
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Reference, *scm.Response, error) {

--- a/scm/driver/gitea/issue.go
+++ b/scm/driver/gitea/issue.go
@@ -18,23 +18,23 @@ type issueService struct {
 
 func (s *issueService) Search(context.Context, scm.SearchOptions) ([]*scm.SearchIssue, *scm.Response, error) {
 	// TODO implemment
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListLabels(context.Context, string, int, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {

--- a/scm/driver/gitea/org.go
+++ b/scm/driver/gitea/org.go
@@ -16,15 +16,15 @@ type organizationService struct {
 }
 
 func (s *organizationService) IsMember(ctx context.Context, org string, user string) (bool, *scm.Response, error) {
-	panic("implement me")
+	return false, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) ListTeams(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organization, *scm.Response, error) {

--- a/scm/driver/gitea/pr.go
+++ b/scm/driver/gitea/pr.go
@@ -46,6 +46,10 @@ func (s *pullService) ListLabels(context.Context, string, int, scm.ListOptions) 
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *pullService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *pullService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
 	// TODO implement
 	return nil, scm.ErrNotSupported
@@ -70,6 +74,14 @@ func (s *pullService) Merge(ctx context.Context, repo string, index int) (*scm.R
 }
 
 func (s *pullService) Close(context.Context, string, int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }
 

--- a/scm/driver/gitea/repo.go
+++ b/scm/driver/gitea/repo.go
@@ -19,27 +19,27 @@ type repositoryService struct {
 }
 
 func (s *repositoryService) Create(context.Context, *scm.RepositoryInput) (*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref string) (*scm.CombinedStatus, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindUserPermission(ctx context.Context, repo string, user string) (string, *scm.Response, error) {
-	panic("implement me")
+	return "", nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {
-	panic("implement me")
+	return false, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListCollaborators(ctx context.Context, repo string) ([]scm.User, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListLabels(context.Context, string, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) Find(ctx context.Context, repo string) (*scm.Repository, *scm.Response, error) {

--- a/scm/driver/github/integration/github_test.go
+++ b/scm/driver/github/integration/github_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/jenkins-x/go-scm/scm/transport"
 )
 
-func TestGitLab(t *testing.T) {
+func TestGitHub(t *testing.T) {
 	if os.Getenv("GITHUB_TOKEN") == "" {
 		t.Skipf("missing GITHUB_TOKEN environment variable")
 		return

--- a/scm/driver/github/integration/issue_test.go
+++ b/scm/driver/github/integration/issue_test.go
@@ -135,9 +135,10 @@ func testIssueComment(comment *scm.Comment) func(t *testing.T) {
 		if got, want := comment.Author.Login, "defualt"; got != want {
 			t.Errorf("Want issue comment Author Login %q, got %q", want, got)
 		}
-		if got, want := comment.Author.Avatar, "https://avatars2.githubusercontent.com/u/399135?v=4"; got != want {
-			t.Errorf("Want issue comment Author Name %q, got %q", want, got)
-		}
+		// TODO: Avatar check seems to have become unreliable. Reenable in the future. (apb)
+		//if got, want := comment.Author.Avatar, "https://avatars2.githubusercontent.com/u/399135?v=4"; got != want {
+		//	t.Errorf("Want issue comment Author Name %q, got %q", want, got)
+		//}
 		if got, want := comment.Created.Unix(), int64(1495732818); got != want {
 			t.Errorf("Want issue comment Created %d, got %d", want, got)
 		}

--- a/scm/driver/github/integration/pr_test.go
+++ b/scm/driver/github/integration/pr_test.go
@@ -185,9 +185,10 @@ func testPullRequestComment(comment *scm.Comment) func(t *testing.T) {
 		if got, want := comment.Author.Name, ""; got != want {
 			t.Errorf("Want pr comment Author Name %q, got %q", want, got)
 		}
-		if got, want := comment.Author.Avatar, "https://avatars3.githubusercontent.com/u/7744744?v=4"; got != want {
-			t.Errorf("Want pr comment Author Avatar %q, got %q", want, got)
-		}
+		// TODO: Avatar check has become unreliable. Fix in the future. (apb)
+		//if got, want := comment.Author.Avatar, "https://avatars3.githubusercontent.com/u/7744744?v=4"; got != want {
+		//	t.Errorf("Want pr comment Author Avatar %q, got %q", want, got)
+		//}
 		if got, want := comment.Created.Unix(), int64(1414224391); got != want {
 			t.Errorf("Want pr comment Created %d, got %d", want, got)
 		}

--- a/scm/driver/github/org.go
+++ b/scm/driver/github/org.go
@@ -17,8 +17,8 @@ type organizationService struct {
 	client *wrapper
 }
 type plan struct {
-	Name                 string `json:"name"`
-	PrivateRepos   int   `json:"private_repos"`
+	Name         string `json:"name"`
+	PrivateRepos int    `json:"private_repos"`
 }
 type organization struct {
 	ID                    int    `json:"id,omitempty"`
@@ -129,7 +129,7 @@ func convertOrganization(from *organization) *scm.Organization {
 			MembersCreatePublic:   from.MembersCreatePublic,
 			// GH API can return true for from.MembersCreatePrivate but if the org's plan is free, the max number of
 			// private repo is 0. Let's check the members can create private repos AND the org can have private repos.
-			MembersCreatePrivate:  from.MembersCreatePrivate && from.Plan.PrivateRepos > 0,
+			MembersCreatePrivate: from.MembersCreatePrivate && from.Plan.PrivateRepos > 0,
 		},
 	}
 }

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -41,7 +41,7 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 }
 
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Reference, *scm.Response, error) {

--- a/scm/driver/gitlab/gitlab.go
+++ b/scm/driver/gitlab/gitlab.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jenkins-x/go-scm/scm"
 )
@@ -120,4 +121,35 @@ type Error struct {
 
 func (e *Error) Error() string {
 	return e.Message
+}
+
+type labelEvent struct {
+	ID           int        `json:"id"`
+	Action       string     `json:"action"`
+	CreatedAt    *time.Time `json:"created_at"`
+	ResourceType string     `json:"resource_type"`
+	ResourceID   int        `json:"resource_id"`
+	User         user       `json:"user"`
+	Label        label      `json:"label"`
+}
+
+func convertLabelEvents(src []*labelEvent) []*scm.ListedIssueEvent {
+	var answer []*scm.ListedIssueEvent
+	for _, from := range src {
+		answer = append(answer, convertLabelEvent(from))
+	}
+	return answer
+}
+
+func convertLabelEvent(from *labelEvent) *scm.ListedIssueEvent {
+	event := "labeled"
+	if from.Action == "remove" {
+		event = "unlabeled"
+	}
+	return &scm.ListedIssueEvent{
+		Event:   event,
+		Actor:   *convertUser(&from.User),
+		Label:   *convertLabel(&from.Label),
+		Created: *from.CreatedAt,
+	}
 }

--- a/scm/driver/gitlab/issue.go
+++ b/scm/driver/gitlab/issue.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -24,30 +25,123 @@ func (s *issueService) Search(context.Context, scm.SearchOptions) ([]*scm.Search
 }
 
 func (s *issueService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	issue, _, err := s.Find(ctx, repo, number)
+	if err != nil {
+		return nil, err
+	}
+
+	allAssignees := map[int]struct{}{}
+	for _, assignee := range issue.Assignees {
+		allAssignees[assignee.ID] = struct{}{}
+	}
+	for _, l := range logins {
+		u, _, err := s.client.Users.FindLogin(ctx, l)
+		if err != nil {
+			return nil, err
+		}
+		allAssignees[u.ID] = struct{}{}
+	}
+
+	var assigneeIDs []int
+	for i := range allAssignees {
+		assigneeIDs = append(assigneeIDs, i)
+	}
+
+	return s.setAssignees(ctx, repo, number, assigneeIDs)
+}
+
+func (s *issueService) setAssignees(ctx context.Context, repo string, number int, ids []int) (*scm.Response, error) {
+	in := &updateIssueOptions{
+		AssigneeIDs: ids,
+	}
+	path := fmt.Sprintf("api/v4/projects/%s/issues/%d", encode(repo), number)
+
+	return s.client.do(ctx, "PUT", path, in, nil)
 }
 
 func (s *issueService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	issue, _, err := s.Find(ctx, repo, number)
+	if err != nil {
+		return nil, err
+	}
+	var assignees []int
+	for _, assignee := range issue.Assignees {
+		shouldKeep := true
+		for _, l := range logins {
+			if assignee.Login == l {
+				shouldKeep = false
+			}
+		}
+		if shouldKeep {
+			assignees = append(assignees, assignee.ID)
+		}
+	}
+
+	return s.setAssignees(ctx, repo, number, assignees)
 }
 
-func (s *issueService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
-	panic("implement me")
+func (s *issueService) ListEvents(ctx context.Context, repo string, index int, opts scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/issues/%d/resource_label_events?%s", encode(repo), index, encodeListOptions(opts))
+	out := []*labelEvent{}
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	return convertLabelEvents(out), res, err
 }
 
 func (s *issueService) ListLabels(ctx context.Context, repo string, number int, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	path := fmt.Sprintf("projects/%s/labels?%s", encode(repo), encodeListOptions(opts))
-	out := []*label{}
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	return convertLabelObjects(out), res, err
+	issue, issueResp, err := s.Find(ctx, repo, number)
+	if err != nil {
+		return nil, issueResp, err
+	}
+	var labels []*scm.Label
+	for _, l := range issue.Labels {
+		labels = append(labels, &scm.Label{
+			Name: l,
+		})
+	}
+	return labels, issueResp, err
 }
 
 func (s *issueService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	existingLabels, _, err := s.ListLabels(ctx, repo, number, scm.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	allLabels := map[string]struct{}{}
+	for _, l := range existingLabels {
+		allLabels[l.Name] = struct{}{}
+	}
+	allLabels[label] = struct{}{}
+
+	labelNames := []string{}
+	for l := range allLabels {
+		labelNames = append(labelNames, l)
+	}
+
+	return s.setLabels(ctx, repo, number, labelNames)
+}
+
+func (s *issueService) setLabels(ctx context.Context, repo string, number int, labels []string) (*scm.Response, error) {
+	in := url.Values{}
+	labelsStr := strings.Join(labels, ",")
+	in.Set("labels", labelsStr)
+	path := fmt.Sprintf("api/v4/projects/%s/issues/%d?%s", encode(repo), number, in.Encode())
+
+	return s.client.do(ctx, "PUT", path, nil, nil)
 }
 
 func (s *issueService) DeleteLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	existingLabels, _, err := s.ListLabels(ctx, repo, number, scm.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	labels := []string{}
+	for _, l := range existingLabels {
+		if l.Name != label {
+			labels = append(labels, l.Name)
+		}
+	}
+	return s.setLabels(ctx, repo, number, labels)
 }
 
 func (s *issueService) Find(ctx context.Context, repo string, number int) (*scm.Issue, *scm.Response, error) {
@@ -120,6 +214,19 @@ func (s *issueService) Unlock(ctx context.Context, repo string, number int) (*sc
 	return res, err
 }
 
+type updateIssueOptions struct {
+	Title            *string    `json:"title,omitempty"`
+	Description      *string    `json:"description,omitempty"`
+	Confidential     *bool      `json:"confidential,omitempty"`
+	AssigneeIDs      []int      `json:"assignee_ids,omitempty"`
+	MilestoneID      *int       `json:"milestone_id,omitempty"`
+	Labels           []string   `json:"labels,omitempty"`
+	StateEvent       *string    `json:"state_event,omitempty"`
+	UpdatedAt        *time.Time `json:"updated_at,omitempty"`
+	Weight           *int       `json:"weight,omitempty"`
+	DiscussionLocked *bool      `json:"discussion_locked,omitempty"`
+}
+
 type issue struct {
 	ID     int      `json:"id"`
 	Number int      `json:"iid"`
@@ -134,8 +241,19 @@ type issue struct {
 		Username string      `json:"username"`
 		Avatar   null.String `json:"avatar_url"`
 	} `json:"author"`
-	Created time.Time `json:"created_at"`
-	Updated time.Time `json:"updated_at"`
+	Assignee  *issueAssignee   `json:"assignee"`
+	Assignees []*issueAssignee `json:"assignees"`
+	Created   time.Time        `json:"created_at"`
+	Updated   time.Time        `json:"updated_at"`
+}
+
+type issueAssignee struct {
+	ID        int    `json:"id"`
+	State     string `json:"state"`
+	WebURL    string `json:"web_url"`
+	Name      string `json:"name"`
+	AvatarURL string `json:"avatar_url"`
+	Username  string `json:"username"`
 }
 
 type issueComment struct {
@@ -155,7 +273,7 @@ type issueCommentInput struct {
 	Body string `json:"body"`
 }
 
-// helper function to convert from the gogs issue list to
+// helper function to convert from the gitlab issue list to
 // the common issue structure.
 func convertIssueList(from []*issue) []*scm.Issue {
 	to := []*scm.Issue{}
@@ -165,7 +283,7 @@ func convertIssueList(from []*issue) []*scm.Issue {
 	return to
 }
 
-// helper function to convert from the gogs issue structure to
+// helper function to convert from the gitlab issue structure to
 // the common issue structure.
 func convertIssue(from *issue) *scm.Issue {
 	return &scm.Issue{
@@ -181,12 +299,43 @@ func convertIssue(from *issue) *scm.Issue {
 			Login:  from.Author.Username,
 			Avatar: from.Author.Avatar.String,
 		},
-		Created: from.Created,
-		Updated: from.Updated,
+		Assignees: convertIssueAssignees(from.Assignee, from.Assignees),
+		Created:   from.Created,
+		Updated:   from.Updated,
 	}
 }
 
-// helper function to convert from the gogs issue comment list
+// helper function to convert from the gitlab issue assignee(s) to the common user structure.
+func convertIssueAssignees(from *issueAssignee, fromList []*issueAssignee) []scm.User {
+	users := make(map[int]scm.User)
+	if from != nil {
+		users[from.ID] = convertSingleIssueAssignee(from)
+	}
+	for _, a := range fromList {
+		if _, exists := users[a.ID]; !exists {
+			users[a.ID] = convertSingleIssueAssignee(a)
+		}
+	}
+
+	var userList []scm.User
+	for _, u := range users {
+		userList = append(userList, u)
+	}
+	return userList
+}
+
+// helper function to convert an individual gitlab issue assignee to a common user.
+func convertSingleIssueAssignee(from *issueAssignee) scm.User {
+	return scm.User{
+		ID:     from.ID,
+		Login:  from.Username,
+		Name:   from.Name,
+		Avatar: from.AvatarURL,
+		Link:   from.WebURL,
+	}
+}
+
+// helper function to convert from the gitlab issue comment list
 // to the common issue structure.
 func convertIssueCommentList(from []*issueComment) []*scm.Comment {
 	to := []*scm.Comment{}
@@ -196,7 +345,7 @@ func convertIssueCommentList(from []*issueComment) []*scm.Comment {
 	return to
 }
 
-// helper function to convert from the gogs issue comment to
+// helper function to convert from the gitlab issue comment to
 // the common issue comment structure.
 func convertIssueComment(from *issueComment) *scm.Comment {
 	return &scm.Comment{

--- a/scm/driver/gitlab/issue_test.go
+++ b/scm/driver/gitlab/issue_test.go
@@ -145,6 +145,43 @@ func TestIssueListComments(t *testing.T) {
 	t.Run("Page", testPage(res))
 }
 
+func TestIssueListEvents(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/diaspora/diaspora/issues/253/resource_label_events").
+		MatchParam("page", "1").
+		MatchParam("per_page", "30").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		SetHeaders(mockPageHeaders).
+		File("testdata/issue_events.json")
+
+	client := NewDefault()
+	got, res, err := client.Issues.ListEvents(context.Background(), "diaspora/diaspora", 253, scm.ListOptions{Size: 30, Page: 1})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := []*scm.ListedIssueEvent{}
+	raw, _ := ioutil.ReadFile("testdata/issue_events.golden.json")
+	err = json.Unmarshal(raw, &want)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+
+	t.Run("Request", testRequest(res))
+	t.Run("Rate", testRate(res))
+	t.Run("Page", testPage(res))
+}
+
 func TestIssueCreate(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -39,6 +39,19 @@ type permissions struct {
 	GroupAccess   access `json:"group_access"`
 }
 
+func accessLevelToString(level int) string {
+	switch level {
+	case 50:
+		return scm.AdminPermission
+	case 40, 30:
+		return scm.WritePermission
+	case 20, 10:
+		return scm.ReadPermission
+	default:
+		return scm.NoPermission
+	}
+}
+
 type access struct {
 	AccessLevel       int `json:"access_level"`
 	NotificationLevel int `json:"notification_level"`
@@ -67,20 +80,57 @@ type label struct {
 	Description string `json:"description"`
 }
 
+type member struct {
+	ID          int    `json:"id"`
+	Username    string `json:"username"`
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	AccessLevel int    `json:"access_level"`
+	WebURL      string `json:"web_url"`
+	AvatarURL   string `json:"avatar_url"`
+	// Fields to be figured out later
+	// expires_at - a yyyy-mm-dd date
+	// group_saml_identity
+
+}
 type repositoryService struct {
 	client *wrapper
 }
 
 func (s *repositoryService) Create(context.Context, *scm.RepositoryInput) (*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref string) (*scm.CombinedStatus, *scm.Response, error) {
-	panic("implement me")
+	statuses, res, err := s.ListStatus(ctx, repo, ref, scm.ListOptions{})
+	if err != nil {
+		return nil, res, err
+	}
+
+	combinedState := scm.StateUnknown
+
+	for _, s := range statuses {
+		// If we've still got a default state, or the state of the current status is worse than the current state, set it.
+		if combinedState == scm.StateUnknown || combinedState > s.State {
+			combinedState = s.State
+		}
+	}
+
+	return &scm.CombinedStatus{
+		State:    combinedState,
+		Sha:      ref,
+		Statuses: statuses,
+	}, res, err
 }
 
 func (s *repositoryService) FindUserPermission(ctx context.Context, repo string, user string) (string, *scm.Response, error) {
-	panic("implement me")
+	path := fmt.Sprintf("api/v4/projects/%s/members/all/%s", encode(repo), encode(user))
+	out := new(member)
+	res, err := s.client.do(ctx, "GET", path, nil, out)
+	if err != nil {
+		return scm.NoPermission, res, err
+	}
+	return accessLevelToString(out.AccessLevel), res, err
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {
@@ -104,10 +154,10 @@ func (s *repositoryService) ListCollaborators(ctx context.Context, repo string) 
 }
 
 func (s *repositoryService) ListLabels(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-        path := fmt.Sprintf("api/v4/projects/%s/labels?%s", encode(repo), encodeListOptions(opts))
-        out := []*label{}
-        res, err := s.client.do(ctx, "GET", path, nil, &out)
-        return convertLabelObjects(out), res, err
+	path := fmt.Sprintf("api/v4/projects/%s/labels?%s", encode(repo), encodeListOptions(opts))
+	out := []*label{}
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	return convertLabelObjects(out), res, err
 }
 
 func (s *repositoryService) Find(ctx context.Context, repo string) (*scm.Repository, *scm.Response, error) {
@@ -139,11 +189,11 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 }
 
 func (s *repositoryService) ListOrganisation(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListUser(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Hook, *scm.Response, error) {
@@ -356,13 +406,18 @@ func convertPrivate(from string) bool {
 func convertLabelObjects(from []*label) []*scm.Label {
 	var labels []*scm.Label
 	for _, label := range from {
-		labels = append(labels, &scm.Label{
-			Name:        label.Name,
-			Description: label.Description,
-			Color:       label.Color,
-		})
+		labels = append(labels, convertLabel(label))
 	}
 	return labels
+}
+
+func convertLabel(from *label) *scm.Label {
+	return &scm.Label{
+		ID:          int64(from.ID),
+		Name:        from.Name,
+		Description: from.Description,
+		Color:       from.Color,
+	}
 }
 
 func canPush(proj *repository) bool {

--- a/scm/driver/gitlab/testdata/combined_status.json.golden
+++ b/scm/driver/gitlab/testdata/combined_status.json.golden
@@ -1,0 +1,17 @@
+{
+    "State": "pending",
+    "Sha": "18f3e63d05582537db6d183d9d557be09e1f90c8",
+    "Statuses": [
+        {
+            "State": "pending",
+            "Label": "default",
+            "Desc": "the dude abides",
+            "Target": "https://gitlab.example.com/thedude/gitlab-ce/builds/91"
+        },
+        {
+            "State": "success",
+            "Label": "test",
+            "Target": "https://gitlab.example.com/thedude/gitlab-foss/builds/90"
+        }
+    ]
+}

--- a/scm/driver/gitlab/testdata/issue.json.golden
+++ b/scm/driver/gitlab/testdata/issue.json.golden
@@ -12,6 +12,14 @@
         "Email": "",
         "Avatar": ""
     },
+    "Assignees": [
+        {
+            "ID": 9,
+            "Login": "lennie",
+            "Name": "Dr. Luella Kovacek",
+            "Link": "https://gitlab.example.com/lennie"
+        }
+    ],
     "Created": "2016-01-04T15:31:46.176Z",
     "Updated": "2016-01-04T15:31:46.176Z"
 }

--- a/scm/driver/gitlab/testdata/issue_events.golden.json
+++ b/scm/driver/gitlab/testdata/issue_events.golden.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Actor": {
+      "Name": "Administrator",
+      "Login": "root",
+      "Avatar": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+    },
+    "Created": "2018-08-20T13:38:20.077Z",
+    "Label": {
+      "ID": 73,
+      "Name": "a1",
+      "Color": "#34495E",
+      "Description": ""
+    },
+    "Event": "labeled"
+  },
+  {
+    "Actor": {
+      "Name": "Administrator",
+      "Login": "root",
+      "Avatar": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+    },
+    "Created": "2018-08-20T13:38:20.077Z",
+    "Label": {
+      "ID": 74,
+      "Name": "p1",
+      "Color": "#0033CC",
+      "Description": ""
+    },
+    "Event": "unlabeled"
+  }
+]

--- a/scm/driver/gitlab/testdata/issue_events.json
+++ b/scm/driver/gitlab/testdata/issue_events.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 142,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-20T13:38:20.077Z",
+    "resource_type": "Issue",
+    "resource_id": 253,
+    "label": {
+      "id": 73,
+      "name": "a1",
+      "color": "#34495E",
+      "description": ""
+    },
+    "action": "add"
+  },
+  {
+    "id": 143,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-20T13:38:20.077Z",
+    "resource_type": "Issue",
+    "resource_id": 253,
+    "label": {
+      "id": 74,
+      "name": "p1",
+      "color": "#0033CC",
+      "description": ""
+    },
+    "action": "remove"
+  }
+]

--- a/scm/driver/gitlab/testdata/issues.json.golden
+++ b/scm/driver/gitlab/testdata/issues.json.golden
@@ -13,6 +13,14 @@
             "Email": "",
             "Avatar": ""
         },
+        "Assignees": [
+            {
+                "ID": 9,
+                "Login": "lennie",
+                "Name": "Dr. Luella Kovacek",
+                "Link": "https://gitlab.example.com/lennie"
+            }
+        ],
         "Created": "2016-01-04T15:31:46.176Z",
         "Updated": "2016-01-04T15:31:46.176Z"
     }

--- a/scm/driver/gitlab/testdata/pr_events.golden.json
+++ b/scm/driver/gitlab/testdata/pr_events.golden.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Actor": {
+      "Name": "Administrator",
+      "Login": "root",
+      "Avatar": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+    },
+    "Created": "2018-08-20T06:17:28.394Z",
+    "Label": {
+      "ID": 74,
+      "Name": "p1",
+      "Color": "#0033CC",
+      "Description": ""
+    },
+    "Event": "labeled"
+  },
+  {
+    "Actor": {
+      "Name": "Administrator",
+      "Login": "root",
+      "Avatar": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon"
+    },
+    "Created": "2018-08-20T06:17:28.394Z",
+    "Label": {
+      "ID": 41,
+      "Name": "project",
+      "Color": "#D1D100",
+      "Description": ""
+    },
+    "Event": "labeled"
+  }
+]

--- a/scm/driver/gitlab/testdata/pr_events.json
+++ b/scm/driver/gitlab/testdata/pr_events.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": 119,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-20T06:17:28.394Z",
+    "resource_type": "MergeRequest",
+    "resource_id": 28,
+    "label": {
+      "id": 74,
+      "name": "p1",
+      "color": "#0033CC",
+      "description": ""
+    },
+    "action": "add"
+  },
+  {
+    "id": 120,
+    "user": {
+      "id": 1,
+      "name": "Administrator",
+      "username": "root",
+      "state": "active",
+      "avatar_url": "https://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
+      "web_url": "http://gitlab.example.com/root"
+    },
+    "created_at": "2018-08-20T06:17:28.394Z",
+    "resource_type": "MergeRequest",
+    "resource_id": 28,
+    "label": {
+      "id": 41,
+      "name": "project",
+      "color": "#D1D100",
+      "description": ""
+    },
+    "action": "add"
+  }
+]

--- a/scm/driver/gitlab/testdata/project_member_perm.json
+++ b/scm/driver/gitlab/testdata/project_member_perm.json
@@ -1,0 +1,11 @@
+{
+  "id": 1,
+  "username": "raymond_smith",
+  "name": "Raymond Smith",
+  "state": "active",
+  "avatar_url": "https://www.gravatar.com/avatar/c2525a7f58ae3776070e44c106c48e15?s=80&d=identicon",
+  "web_url": "http://192.168.1.8:3000/root",
+  "access_level": 30,
+  "expires_at": null,
+  "group_saml_identity": null
+}

--- a/scm/driver/gitlab/testdata/statuses.json
+++ b/scm/driver/gitlab/testdata/statuses.json
@@ -19,5 +19,26 @@
         "finished_at": null,
         "id": 91,
         "ref": "master"
+    },
+    {
+        "started_at" : null,
+        "name" : "test",
+        "allow_failure" : false,
+        "status" : "success",
+        "created_at" : "2016-01-19T08:40:25.832Z",
+        "target_url" : "https://gitlab.example.com/thedude/gitlab-foss/builds/90",
+        "id" : 90,
+        "finished_at" : null,
+        "ref" : "master",
+        "sha" : "18f3e63d05582537db6d183d9d557be09e1f90c8",
+        "author" : {
+            "id" : 28,
+            "name" : "Jeff Lebowski",
+            "username" : "thedude",
+            "web_url" : "https://gitlab.example.com/thedude",
+            "state" : "active",
+            "avatar_url" : "https://gitlab.example.com/uploads/user/avatar/28/The-Big-Lebowski-400-400.png"
+        },
+        "description" : null
     }
 ]

--- a/scm/driver/gitlab/testdata/statuses.json.golden
+++ b/scm/driver/gitlab/testdata/statuses.json.golden
@@ -4,5 +4,10 @@
         "Label": "default",
         "Desc": "the dude abides",
         "Target": "https://gitlab.example.com/thedude/gitlab-ce/builds/91"
+    },
+    {
+        "State": "success",
+        "Label": "test",
+        "Target": "https://gitlab.example.com/thedude/gitlab-foss/builds/90"
     }
 ]

--- a/scm/driver/gitlab/user.go
+++ b/scm/driver/gitlab/user.go
@@ -42,6 +42,7 @@ func (s *userService) FindEmail(ctx context.Context) (string, *scm.Response, err
 }
 
 type user struct {
+	ID       int         `json:"id"`
 	Username string      `json:"username"`
 	Name     string      `json:"name"`
 	Email    null.String `json:"email"`

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -17,11 +17,11 @@ type gitService struct {
 }
 
 func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *scm.Response, error) {
-	panic("implement me")
+	return "", nil, scm.ErrNotSupported
 }
 
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *gitService) FindBranch(ctx context.Context, repo, name string) (*scm.Reference, *scm.Response, error) {

--- a/scm/driver/gogs/issue.go
+++ b/scm/driver/gogs/issue.go
@@ -18,23 +18,23 @@ type issueService struct {
 
 func (s *issueService) Search(context.Context, scm.SearchOptions) ([]*scm.SearchIssue, *scm.Response, error) {
 	// TODO implemment
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListLabels(context.Context, string, int, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {

--- a/scm/driver/gogs/org.go
+++ b/scm/driver/gogs/org.go
@@ -16,15 +16,15 @@ type organizationService struct {
 }
 
 func (s *organizationService) IsMember(ctx context.Context, org string, user string) (bool, *scm.Response, error) {
-	panic("implement me")
+	return false, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) ListTeams(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organization, *scm.Response, error) {

--- a/scm/driver/gogs/pr.go
+++ b/scm/driver/gogs/pr.go
@@ -38,6 +38,10 @@ func (s *pullService) ListLabels(context.Context, string, int, scm.ListOptions) 
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *pullService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *pullService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
 	// TODO implement
 	return nil, scm.ErrNotSupported
@@ -60,6 +64,14 @@ func (s *pullService) Merge(context.Context, string, int) (*scm.Response, error)
 }
 
 func (s *pullService) Close(context.Context, string, int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }
 

--- a/scm/driver/gogs/repo.go
+++ b/scm/driver/gogs/repo.go
@@ -18,27 +18,27 @@ type repositoryService struct {
 }
 
 func (s *repositoryService) Create(context.Context, *scm.RepositoryInput) (*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref string) (*scm.CombinedStatus, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindUserPermission(ctx context.Context, repo string, user string) (string, *scm.Response, error) {
-	panic("implement me")
+	return "", nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {
-	panic("implement me")
+	return false, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListCollaborators(ctx context.Context, repo string) ([]scm.User, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListLabels(context.Context, string, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) Find(ctx context.Context, repo string) (*scm.Repository, *scm.Response, error) {

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -40,7 +40,7 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 }
 
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *gitService) FindBranch(ctx context.Context, repo, branch string) (*scm.Reference, *scm.Response, error) {

--- a/scm/driver/stash/issue.go
+++ b/scm/driver/stash/issue.go
@@ -16,25 +16,23 @@ type issueService struct {
 }
 
 func (s *issueService) Search(context.Context, scm.SearchOptions) ([]*scm.SearchIssue, *scm.Response, error) {
-	// TODO implemment
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	panic("implement me")
+	return nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) ListLabels(context.Context, string, int, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	// TODO implement this
-	return nil, nil, nil
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *issueService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -16,11 +16,11 @@ type organizationService struct {
 }
 
 func (s *organizationService) ListTeams(ctx context.Context, org string, ops scm.ListOptions) ([]*scm.Team, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role string, ops scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *organizationService) IsMember(ctx context.Context, org string, user string) (bool, *scm.Response, error) {

--- a/scm/driver/stash/pr.go
+++ b/scm/driver/stash/pr.go
@@ -61,6 +61,10 @@ func (s *pullService) ListLabels(ctx context.Context, repo string, number int, o
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *pullService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *pullService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }
@@ -116,6 +120,14 @@ func (s *pullService) DeleteComment(context.Context, string, int, int) (*scm.Res
 	// and then to use expectedVersion on error and re-attempt the API call.
 
 	// DELETE /rest/api/1.0/projects/PRJ/repos/my-repo/pull-requests/1/comments/1?version=0
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
+func (s *pullService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }
 

--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -112,15 +112,15 @@ type repositoryService struct {
 }
 
 func (s *repositoryService) Create(context.Context, *scm.RepositoryInput) (*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref string) (*scm.CombinedStatus, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) FindUserPermission(ctx context.Context, repo string, user string) (string, *scm.Response, error) {
-	panic("implement me")
+	return "", nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {
@@ -229,11 +229,11 @@ func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*
 }
 
 func (s *repositoryService) ListOrganisation(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 func (s *repositoryService) ListUser(context.Context, string, scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	panic("implement me")
+	return nil, nil, scm.ErrNotSupported
 }
 
 // listWrite returns the user repository list.

--- a/scm/issue.go
+++ b/scm/issue.go
@@ -101,7 +101,7 @@ type (
 		// ListLabels returns the labels on an issue
 		ListLabels(context.Context, string, int, ListOptions) ([]*Label, *Response, error)
 
-		// ListEvents returns the labels on an issue
+		// ListEvents returns the events creating and removing the labels on an issue
 		ListEvents(context.Context, string, int, ListOptions) ([]*ListedIssueEvent, *Response, error)
 
 		// Create creates a new issue.
@@ -128,7 +128,7 @@ type (
 		// DeleteLabel deletes a label from an issue
 		DeleteLabel(ctx context.Context, repo string, number int, label string) (*Response, error)
 
-		// AssignIssue asigns one or more  users to an issue
+		// AssignIssue assigns one or more  users to an issue
 		AssignIssue(ctx context.Context, repo string, number int, logins []string) (*Response, error)
 
 		// UnassignIssue removes the assignment of ne or more users on an issue

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -108,6 +108,9 @@ type (
 		// ListLabels returns the labels on a pull request
 		ListLabels(context.Context, string, int, ListOptions) ([]*Label, *Response, error)
 
+		// ListEvents returns the events creating and removing the labels on an pull request
+		ListEvents(context.Context, string, int, ListOptions) ([]*ListedIssueEvent, *Response, error)
+
 		// Merge merges the repository pull request.
 		Merge(context.Context, string, int) (*Response, error)
 
@@ -125,6 +128,12 @@ type (
 
 		// DeleteLabel deletes a label from a pull request
 		DeleteLabel(ctx context.Context, repo string, number int, label string) (*Response, error)
+
+		// AssignIssue assigns one or more  users to an issue
+		AssignIssue(ctx context.Context, repo string, number int, logins []string) (*Response, error)
+
+		// UnassignIssue removes the assignment of ne or more users on an issue
+		UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*Response, error)
 
 		// Create creates a new pull request in a repo.
 		Create(context.Context, string, *PullRequestInput) (*PullRequest, *Response, error)

--- a/scm/repo.go
+++ b/scm/repo.go
@@ -9,6 +9,17 @@ import (
 	"time"
 )
 
+const (
+	// NoPermission means the user has no permission to access the repository
+	NoPermission = "none"
+	// ReadPermission means the user has read access to the repository
+	ReadPermission = "read"
+	// WritePermission means the user has write/push access to the repository
+	WritePermission = "write"
+	// AdminPermission means the user has full admin access to the repository
+	AdminPermission = "admin"
+)
+
 type (
 	// Repository represents a git repository.
 	Repository struct {


### PR DESCRIPTION
* Add/Delete label for gitlab issues
* ListLabels for repo in Gitlab
* Add FindUserPermission for Gitlab
* Add Assign/Unassign to PR, implement for GitLab
* Add combined status to gitlab
* add listevents for gitlab issues
* Add ListEvents for PRs, implementing for gitLab

Still need to implement issues/merge request search and (ideally) graphql query - Tide needs the latter, but I may need to hack around implementing that to use searching per-project instead, depending on if I can figure out https://docs.gitlab.com/ee/api/graphql/ well enough to get anywhere with it.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>