### PR TITLE
Make github driver return scm.ErrNotFound.

### DIFF
--- a/scm/driver/github/github.go
+++ b/scm/driver/github/github.go
@@ -150,6 +150,9 @@ func (c *wrapper) doRequest(ctx context.Context, req *scm.Request, in, out inter
 	// if an error is encountered, unmarshal and return the
 	// error response.
 	if res.Status > 300 {
+		if res.Status == 404 {
+			return res, scm.ErrNotFound
+		}
 		err := new(Error)
 		json.NewDecoder(res.Body).Decode(err)
 		return res, err


### PR DESCRIPTION
Support consistent error handling across providers (at least regarding `github` and `fake` driver for now) when it comes to resources that could not be found.
fake driver already behaves correspondingly. However since it does not
return a HTTP response it is not possible to have one condition for
a 'not found' error that works for both providers. This PR makes that
possible now.