### PR TITLE
fix: Handle BitBucket Server "pr:from_ref_updated" hook

### DIFF
--- a/scm/driver/fake/org.go
+++ b/scm/driver/fake/org.go
@@ -39,16 +39,16 @@ func (s *organizationService) List(context.Context, scm.ListOptions) ([]*scm.Org
 	var orgs []*scm.Organization
 	for i := 0; i < 5; i++ {
 		org := scm.Organization{
-			ID:          i,
-			Name:        fmt.Sprintf("organisation%d", i),
-			Avatar:      fmt.Sprintf("https://github.com/organisation%d.png", i),
+			ID:     i,
+			Name:   fmt.Sprintf("organisation%d", i),
+			Avatar: fmt.Sprintf("https://github.com/organisation%d.png", i),
 			Permissions: scm.Permissions{
 				true,
 				true,
 				true,
 			},
 		}
-		orgs = append(orgs, &org);
+		orgs = append(orgs, &org)
 	}
 	return orgs, &scm.Response{}, nil
 }

--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -233,13 +233,13 @@ func (s *pullService) updateMergeRequestField(ctx context.Context, repo string, 
 }
 
 type pr struct {
-	Number int    `json:"iid"`
-	Sha    string `json:"sha"`
-	Title  string `json:"title"`
-	Desc   string `json:"description"`
-	State  string `json:"state"`
+	Number int       `json:"iid"`
+	Sha    string    `json:"sha"`
+	Title  string    `json:"title"`
+	Desc   string    `json:"description"`
+	State  string    `json:"state"`
 	Labels []*string `json:"labels"`
-	Link   string `json:"web_url"`
+	Link   string    `json:"web_url"`
 	Author struct {
 		Username string `json:"username"`
 		Email    string `json:"email"`
@@ -323,16 +323,15 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 }
 
 func convertPullRequestLabels(from []*string) []*scm.Label {
-        var labels []*scm.Label
-        for _, label := range from {
-               l := *label
-                labels = append(labels, &scm.Label{
-                        Name:        l,
-                })
-        }
-        return labels
+	var labels []*scm.Label
+	for _, label := range from {
+		l := *label
+		labels = append(labels, &scm.Label{
+			Name: l,
+		})
+	}
+	return labels
 }
-
 
 func convertChangeList(from []*change) []*scm.Change {
 	to := []*scm.Change{}

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -132,7 +132,7 @@ func parseCommentHook(data []byte) (scm.Webhook, error) {
 func convertPushHook(src *pushHook) *scm.PushHook {
 	repo := *convertRepositoryHook(&src.Project)
 	dst := &scm.PushHook{
-		Ref: scm.ExpandRef(src.Ref, "refs/heads/"),
+		Ref:  scm.ExpandRef(src.Ref, "refs/heads/"),
 		Repo: repo,
 		Commit: scm.Commit{
 			Sha:     src.CheckoutSha,
@@ -277,7 +277,7 @@ func convertPullRequestHook(src *pullRequestHook) *scm.PullRequestHook {
 }
 
 func convertMergeRequestCommentHook(src *commentHook) *scm.PullRequestCommentHook {
-	user :=  scm.User{
+	user := scm.User{
 		ID:     src.ObjectAttributes.AuthorID,
 		Login:  src.User.Username,
 		Name:   src.User.Name,
@@ -311,15 +311,15 @@ func convertMergeRequestCommentHook(src *commentHook) *scm.PullRequestCommentHoo
 			Ref: src.MergeRequest.SourceBranch,
 			Sha: sha,
 		},
-		Source: src.MergeRequest.SourceBranch,
-		Target: src.MergeRequest.TargetBranch,
-		Fork:   fork,
-		Link:   src.MergeRequest.URL,
-		Closed: src.MergeRequest.State != "opened",
-		Merged: src.MergeRequest.State == "merged",
+		Source:  src.MergeRequest.SourceBranch,
+		Target:  src.MergeRequest.TargetBranch,
+		Fork:    fork,
+		Link:    src.MergeRequest.URL,
+		Closed:  src.MergeRequest.State != "opened",
+		Merged:  src.MergeRequest.State == "merged",
 		Created: created_pr_at,
 		Updated: updated_pr_at, // 2017-12-10 17:01:11 UTC
-		Author: user,
+		Author:  user,
 	}
 	pr.Base.Repo = repo
 	pr.Head.Repo = repo
@@ -328,8 +328,8 @@ func convertMergeRequestCommentHook(src *commentHook) *scm.PullRequestCommentHoo
 	updated_at, _ := time.Parse("2006-01-02 15:04:05 MST", src.ObjectAttributes.UpdatedAt)
 
 	return &scm.PullRequestCommentHook{
-		Action: scm.ActionCreate,
-		Repo: repo,
+		Action:      scm.ActionCreate,
+		Repo:        repo,
 		PullRequest: pr,
 		Comment: scm.Comment{
 			ID:      src.ObjectAttributes.ID,
@@ -391,7 +391,7 @@ type (
 		UserAvatar   string      `json:"user_avatar"`
 		ProjectID    int         `json:"project_id"`
 		Project      project     `json:"project"`
-		Commits []struct {
+		Commits      []struct {
 			ID        string `json:"id"`
 			Message   string `json:"message"`
 			Timestamp string `json:"timestamp"`
@@ -423,8 +423,8 @@ type (
 			Username  string `json:"username"`
 			AvatarURL string `json:"avatar_url"`
 		} `json:"user"`
-		ProjectID int `json:"project_id"`
-		Project   project     `json:"project"`
+		ProjectID        int     `json:"project_id"`
+		Project          project `json:"project"`
 		ObjectAttributes struct {
 			ID           int         `json:"id"`
 			Note         string      `json:"note"`
@@ -581,8 +581,8 @@ type (
 		UserEmail    string      `json:"user_email"`
 		UserAvatar   string      `json:"user_avatar"`
 		ProjectID    int         `json:"project_id"`
-		Project   project     `json:"project"`
-		Commits []struct {
+		Project      project     `json:"project"`
+		Commits      []struct {
 			ID        string `json:"id"`
 			Message   string `json:"message"`
 			Timestamp string `json:"timestamp"`
@@ -614,7 +614,7 @@ type (
 			Username  string `json:"username"`
 			AvatarURL string `json:"avatar_url"`
 		} `json:"user"`
-		Project   project     `json:"project"`
+		Project          project `json:"project"`
 		ObjectAttributes struct {
 			AssigneeID          interface{}   `json:"assignee_id"`
 			AuthorID            int           `json:"author_id"`
@@ -689,7 +689,7 @@ type (
 			Username  string `json:"username"`
 			AvatarURL string `json:"avatar_url"`
 		} `json:"user"`
-		Project   project     `json:"project"`
+		Project          project `json:"project"`
 		ObjectAttributes struct {
 			AssigneeID     interface{} `json:"assignee_id"`
 			AuthorID       int         `json:"author_id"`

--- a/scm/driver/gitlab/webhook_test.go
+++ b/scm/driver/gitlab/webhook_test.go
@@ -109,7 +109,7 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/pull_request_merge.json.golden",
 			obj:    new(scm.PullRequestHook),
 		},
-                // pull request comment hooks
+		// pull request comment hooks
 		{
 			event:  "Note Hook",
 			before: "testdata/webhooks/pull_request_comment_create.json",

--- a/scm/driver/stash/testdata/webhooks/pr_ref_updated.json
+++ b/scm/driver/stash/testdata/webhooks/pr_ref_updated.json
@@ -1,0 +1,86 @@
+{
+    "eventKey": "pr:from_ref_updated",
+    "date": "2018-07-05T19:21:30+0000",
+    "actor": {
+        "name": "jcitizen",
+        "emailAddress": "jane@example.com",
+        "id": 1,
+        "displayName": "Jane Citizen",
+        "active": true,
+        "slug": "jcitizen",
+        "type": "NORMAL"
+    },
+    "pullRequest": {
+        "id": 2,
+        "version": 0,
+        "title": "added LICENSE",
+        "description": "added BSD license text",
+        "state": "OPEN",
+        "open": true,
+        "closed": false,
+        "createdDate": 1530818490848,
+        "updatedDate": 1530818490848,
+        "fromRef": {
+            "id": "refs/heads/develop",
+            "displayId": "develop",
+            "latestCommit": "208b0a5c05eddadad01f2aed8802fe0c3b3eaf5e",
+            "repository": {
+                "slug": "my-repo",
+                "id": 1,
+                "name": "my-repo",
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "statusMessage": "Available",
+                "forkable": true,
+                "project": {
+                    "key": "PRJ",
+                    "id": 2,
+                    "name": "PRJ",
+                    "public": false,
+                    "type": "NORMAL"
+                },
+                "public": false
+            }
+        },
+        "toRef": {
+            "id": "refs/heads/master",
+            "displayId": "master",
+            "latestCommit": "823b2230a56056231c9425d63758fa87078a66b4",
+            "repository": {
+                "slug": "my-repo",
+                "id": 1,
+                "name": "my-repo",
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "statusMessage": "Available",
+                "forkable": true,
+                "project": {
+                    "key": "PRJ",
+                    "id": 2,
+                    "name": "PRJ",
+                    "public": false,
+                    "type": "NORMAL"
+                },
+                "public": false
+            }
+        },
+        "locked": false,
+        "author": {
+            "user": {
+                "name": "jcitizen",
+                "emailAddress": "jane@example.com",
+                "id": 1,
+                "displayName": "Jane Citizen",
+                "active": true,
+                "slug": "jcitizen",
+                "type": "NORMAL"
+            },
+            "role": "AUTHOR",
+            "approved": false,
+            "status": "UNAPPROVED"
+        },
+        "reviewers": [],
+        "participants": []
+    },
+    "previousFromHash": "99f3ea32043ba3ecaa28de6046b420de70257d80"
+}

--- a/scm/driver/stash/testdata/webhooks/pr_ref_updated.json.golden
+++ b/scm/driver/stash/testdata/webhooks/pr_ref_updated.json.golden
@@ -1,0 +1,78 @@
+{
+  "Action": "synchronized",
+  "Repo": {
+    "ID": "1",
+    "Namespace": "PRJ",
+    "Name": "my-repo",
+    "Perm": null,
+    "Branch": "master",
+    "Private": true,
+    "Clone": "",
+    "CloneSSH": "",
+    "Link": "",
+    "Created": "0001-01-01T00:00:00Z",
+    "Updated": "0001-01-01T00:00:00Z"
+  },
+  "PullRequest": {
+    "Number": 2,
+    "Title": "added LICENSE",
+    "Body": "added BSD license text",
+    "Sha": "208b0a5c05eddadad01f2aed8802fe0c3b3eaf5e",
+    "Ref": "refs/pull-requests/2/from",
+    "Source": "develop",
+    "Target": "master",
+    "Fork": "PRJ/my-repo",
+    "Link": "",
+    "Closed": false,
+    "Merged": false,
+    "State": "open",
+    "Base": {
+      "Ref": "master",
+      "Sha": "208b0a5c05eddadad01f2aed8802fe0c3b3eaf5e",
+      "Repo": {
+        "ID": "1",
+        "Namespace": "PRJ",
+        "Name": "my-repo",
+        "Perm": null,
+        "Branch": "master",
+        "Private": true,
+        "Clone": "",
+        "CloneSSH": "",
+        "Link": "",
+        "Created": "0001-01-01T00:00:00Z",
+        "Updated": "0001-01-01T00:00:00Z"
+      }
+    },
+    "Head": {
+      "Ref": "master",
+      "Sha": "208b0a5c05eddadad01f2aed8802fe0c3b3eaf5e",
+      "Repo": {
+        "ID": "1",
+        "Namespace": "PRJ",
+        "Name": "my-repo",
+        "Perm": null,
+        "Branch": "master",
+        "Private": true,
+        "Clone": "",
+        "CloneSSH": "",
+        "Link": "",
+        "Created": "0001-01-01T00:00:00Z",
+        "Updated": "0001-01-01T00:00:00Z"
+      }
+    },
+    "Author": {
+      "Login": "jcitizen",
+      "Name": "Jane Citizen",
+      "Email": "jane@example.com",
+      "Avatar": "https://www.gravatar.com/avatar/9e26471d35a78862c17e467d87cddedf.jpg"
+    },
+    "Created": "2018-07-05T12:21:30-07:00",
+    "Updated": "2018-07-05T12:21:30-07:00"
+  },
+  "Sender": {
+    "Login": "jcitizen",
+    "Name": "Jane Citizen",
+    "Email": "jane@example.com",
+    "Avatar": "https://www.gravatar.com/avatar/9e26471d35a78862c17e467d87cddedf.jpg"
+  }
+}

--- a/scm/driver/stash/webhook.go
+++ b/scm/driver/stash/webhook.go
@@ -43,7 +43,7 @@ func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhoo
 	switch req.Header.Get("X-Event-Key") {
 	case "repo:refs_changed":
 		hook, err = s.parsePushHook(data)
-	case "pr:opened", "pr:declined", "pr:merged":
+	case "pr:opened", "pr:declined", "pr:merged", "pr:from_ref_updated":
 		hook, err = s.parsePullRequest(data)
 	case "pr:comment:added":
 		hook, err = s.parsePullRequestComment(data)
@@ -107,6 +107,8 @@ func (s *webhookService) parsePullRequest(data []byte) (scm.Webhook, error) {
 		dst.Action = scm.ActionClose
 	case "pr:merged":
 		dst.Action = scm.ActionMerge
+	case "pr:from_ref_updated":
+		dst.Action = scm.ActionSync
 	default:
 		return nil, nil
 	}
@@ -121,7 +123,6 @@ func (s *webhookService) parsePullRequestComment(data []byte) (scm.Webhook, erro
 	}
 	dst := convertPullRequestCommentHook(src)
 	return dst, nil
-
 }
 
 //
@@ -137,10 +138,11 @@ type pushHook struct {
 }
 
 type pullRequestHook struct {
-	EventKey    string       `json:"eventKey"`
-	Date        string       `json:"date"`
-	Actor       *user        `json:"actor"`
-	PullRequest *pullRequest `json:"pullRequest"`
+	EventKey         string       `json:"eventKey"`
+	Date             string       `json:"date"`
+	Actor            *user        `json:"actor"`
+	PullRequest      *pullRequest `json:"pullRequest"`
+	PreviousFromHash string       `json:"previousFromHash"`
 }
 
 type pullRequestCommentHook struct {


### PR DESCRIPTION
Introduced in BitBucket Server 7.0 - as far as I can tell, there isn't yet an equivalent in BitBucket Cloud.

fixes https://github.com/jenkins-x/lighthouse/issues/511

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>