### PR TITLE
fix: Get full user list for permissions check on GitLab

### DIFF
--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -124,13 +124,18 @@ func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref st
 }
 
 func (s *repositoryService) FindUserPermission(ctx context.Context, repo string, user string) (string, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/members/all/%s", encode(repo), encode(user))
-	out := new(member)
-	res, err := s.client.do(ctx, "GET", path, nil, out)
+	path := fmt.Sprintf("api/v4/projects/%s/members/all", encode(repo))
+	out := []*member{}
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	if err != nil {
 		return scm.NoPermission, res, err
 	}
-	return accessLevelToString(out.AccessLevel), res, err
+	for _, u := range out {
+		if u.Username == user {
+			return accessLevelToString(u.AccessLevel), res, nil
+		}
+	}
+	return scm.NoPermission, res, nil
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {

--- a/scm/driver/gitlab/repo_test.go
+++ b/scm/driver/gitlab/repo_test.go
@@ -406,11 +406,11 @@ func TestRepositoryFindUserPermission(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://gitlab.com").
-		Get("/api/v4/projects/diaspora/diaspora/members/all/raymond_smith").
+		Get("/api/v4/projects/diaspora/diaspora/members/all").
 		Reply(200).
 		Type("application/json").
 		SetHeaders(mockHeaders).
-		File("testdata/project_member_perm.json")
+		File("testdata/contributors.json")
 
 	client := NewDefault()
 	got, res, err := client.Repositories.FindUserPermission(context.Background(), "diaspora/diaspora", "raymond_smith")


### PR DESCRIPTION
Otherwise we need an extra API call to look up the user's ID from the login.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>