### PR TITLE
fix: Shouldn't include "refs/heads/" in GitLab MR base/target refs

### DIFF
--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -327,14 +327,14 @@ func convertPullRequest(from *pr) *scm.PullRequest {
 			Avatar: from.Author.Avatar,
 		},
 		Head: scm.PullRequestBranch{
-			Ref: fmt.Sprintf("refs/heads/%s", from.SourceBranch),
+			Ref: from.SourceBranch,
 			Sha: headSHA,
 			Repo: scm.Repository{
 				ID: strconv.Itoa(from.SourceProjectID),
 			},
 		},
 		Base: scm.PullRequestBranch{
-			Ref: fmt.Sprintf("refs/heads/%s", from.TargetBranch),
+			Ref: from.TargetBranch,
 			Sha: from.DiffRefs.BaseSHA,
 			Repo: scm.Repository{
 				ID: strconv.Itoa(from.TargetProjectID),

--- a/scm/driver/gitlab/testdata/merge.json.golden
+++ b/scm/driver/gitlab/testdata/merge.json.golden
@@ -22,14 +22,14 @@
     "Created": "2015-12-18T18:29:53.563Z",
     "Updated": "2015-12-18T18:30:22.522Z",
     "Head": {
-        "Ref": "refs/heads/fix",
+        "Ref": "fix",
         "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
         "Repo": {
             "ID": "32732"
         }
     },
     "Base": {
-        "Ref": "refs/heads/master",
+        "Ref": "master",
         "Repo": {
             "ID": "32732"
         }

--- a/scm/driver/gitlab/testdata/merges.json.golden
+++ b/scm/driver/gitlab/testdata/merges.json.golden
@@ -23,14 +23,14 @@
         "Created": "2015-12-18T18:29:53.563Z",
         "Updated": "2015-12-18T18:30:22.522Z",
         "Head": {
-            "Ref": "refs/heads/fix",
+            "Ref": "fix",
             "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
             "Repo": {
                 "ID": "32732"
             }
         },
         "Base": {
-            "Ref": "refs/heads/master",
+            "Ref": "master",
             "Repo": {
                 "ID": "32732"
             }

--- a/scm/driver/gitlab/testdata/pr_create.json.golden
+++ b/scm/driver/gitlab/testdata/pr_create.json.golden
@@ -8,7 +8,7 @@
   "Source": "test1",
   "Target": "master",
   "Base": {
-    "Ref": "refs/heads/master",
+    "Ref": "master",
     "Sha": "c380d3acebd181f13629a25d2e2acca46ffe1e00",
     "Repo": {
       "ID": "3",
@@ -26,7 +26,7 @@
     }
   },
   "Head": {
-    "Ref": "refs/heads/test1",
+    "Ref": "test1",
     "Sha": "8888888888888888888888888888888888888888",
     "Repo": {
       "ID": "2",


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>