### PR TITLE
fix: Fake client to create hook with generated ID and delete hook by ID.

### DIFF
--- a/scm/driver/fake/data.go
+++ b/scm/driver/fake/data.go
@@ -103,5 +103,6 @@ func NewData() *Data {
 		CommentReactionsAdded:     []string{},
 		AssigneesAdded:            []string{},
 		UserPermissions:           map[string]map[string]string{},
+		Hooks:                     map[string][]*scm.Hook{},
 	}
 }

--- a/scm/driver/fake/repo.go
+++ b/scm/driver/fake/repo.go
@@ -3,6 +3,7 @@ package fake
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -125,7 +126,7 @@ func (s *repositoryService) ListHooks(ctx context.Context, fullName string, opts
 
 func (s *repositoryService) CreateHook(ctx context.Context, fullName string, input *scm.HookInput) (*scm.Hook, *scm.Response, error) {
 	hook := &scm.Hook{
-		ID:     input.Name,
+		ID:     fmt.Sprintf("%d", rand.Int()),
 		Name:   input.Name,
 		Target: input.Target,
 		Active: true,

--- a/scm/driver/fake/repo.go
+++ b/scm/driver/fake/repo.go
@@ -125,7 +125,7 @@ func (s *repositoryService) ListHooks(ctx context.Context, fullName string, opts
 
 func (s *repositoryService) CreateHook(ctx context.Context, fullName string, input *scm.HookInput) (*scm.Hook, *scm.Response, error) {
 	hook := &scm.Hook{
-		ID:     "dummy",
+		ID:     input.Name,
 		Name:   input.Name,
 		Target: input.Target,
 		Active: true,
@@ -134,10 +134,10 @@ func (s *repositoryService) CreateHook(ctx context.Context, fullName string, inp
 	return hook, nil, nil
 }
 
-func (s *repositoryService) DeleteHook(ctx context.Context, fullName string, hookName string) (*scm.Response, error) {
+func (s *repositoryService) DeleteHook(ctx context.Context, fullName string, hookID string) (*scm.Response, error) {
 	hooks := s.data.Hooks[fullName]
 	for i, h := range hooks {
-		if h.Name == hookName {
+		if h.ID == hookID {
 			hooks = append(hooks[0:i], hooks[i+1:]...)
 			s.data.Hooks[fullName] = hooks
 			break

--- a/scm/driver/fake/repo_test.go
+++ b/scm/driver/fake/repo_test.go
@@ -1,0 +1,60 @@
+package fake
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jenkins-x/go-scm/scm"
+)
+
+func TestHookCreateDelete(t *testing.T) {
+
+	client, _ := NewDefault()
+
+	in := &scm.HookInput{
+		Target: "https://example.com",
+		Name:   "test",
+	}
+
+	// create a hook
+	createdHook, _, err := client.Repositories.CreateHook(context.Background(), "foo/repo", in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	id := createdHook.ID
+	if id == "" {
+		t.Fatal("created hook must have an ID")
+	}
+
+	// list to verify created hook
+	hooks, _, err := client.Repositories.ListHooks(context.Background(), "foo/repo", scm.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hooks) != 1 {
+		t.Fatal("expect one hook")
+	}
+
+	if diff := cmp.Diff(id, hooks[0].ID); diff != "" {
+		t.Fatalf("hook id mismatch got\n%s", diff)
+	}
+
+	// delete by hook ID
+	_, err = client.Repositories.DeleteHook(context.Background(), "foo/repo", id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// list to verify deletion
+	hooks, _, err = client.Repositories.ListHooks(context.Background(), "foo/repo", scm.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(hooks) != 0 {
+		t.Fatal("expect no hooks")
+	}
+}


### PR DESCRIPTION
This PR proposes the following changes to Fake Client.

* Use hook ID to find target hook to delete instead of using hook name.  
* CreateHook to generate a hook ID instead of using "dummy".   
* Initialize fake `Data`'s `Hooks map` 

 The above changes allow more meaningful mocking/testing.   Note:.  if tests want to use `factory.NewClient("fake", "", "")`to construct a client, fake `Data` is not available to test code.