### PR TITLE
fix: Need to specify 0 as assignee id when removing all existing ones from GitLab

### DIFF
--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -175,6 +175,9 @@ func (s *pullService) AssignIssue(ctx context.Context, repo string, number int, 
 }
 
 func (s *pullService) setAssignees(ctx context.Context, repo string, number int, ids []int) (*scm.Response, error) {
+	if len(ids) == 0 {
+		ids = append(ids, 0)
+	}
 	in := &updateMergeRequestOptions{
 		AssigneeIDs: ids,
 	}


### PR DESCRIPTION

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>