### PR TITLE
chore: Add a number of BitBucket Server implementations

### DIFF
--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -116,11 +117,60 @@ func (s *repositoryService) Create(context.Context, *scm.RepositoryInput) (*scm.
 }
 
 func (s *repositoryService) FindCombinedStatus(ctx context.Context, repo, ref string) (*scm.CombinedStatus, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+	path := fmt.Sprintf("rest/build-status/1.0/commits/%s?orderBy=oldest", ref)
+	out := new(statuses)
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+
+	if err != nil {
+		return nil, res, err
+	}
+
+	combinedState := scm.StateUnknown
+
+	byContext := make(map[string]*status)
+	for _, s := range out.Values {
+		byContext[s.Key] = s
+	}
+
+	keys := make([]string, 0, len(byContext))
+	for k := range byContext {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var statuses []*scm.Status
+	for _, k := range keys {
+		s := byContext[k]
+		statuses = append(statuses, convertStatus(s))
+	}
+
+	for _, s := range statuses {
+		// If we've still got a default state, or the state of the current status is worse than the current state, set it.
+		if combinedState == scm.StateUnknown || combinedState > s.State {
+			combinedState = s.State
+		}
+	}
+
+	return &scm.CombinedStatus{
+		State:    combinedState,
+		Sha:      ref,
+		Statuses: statuses,
+	}, res, err
 }
 
 func (s *repositoryService) FindUserPermission(ctx context.Context, repo string, user string) (string, *scm.Response, error) {
-	return "", nil, scm.ErrNotSupported
+	namespace, name := scm.Split(repo)
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/permissions/users?filter=%s", namespace, name, user)
+	out := new(participants)
+	res, err := s.client.do(ctx, "GET", path, nil, out)
+	if err != nil {
+		return "", res, err
+	}
+	for _, p := range out.Values {
+		if p.User.Name == user {
+			return permissionToString(p.Permission), res, nil
+		}
+	}
+	return "", res, nil
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {
@@ -415,7 +465,7 @@ func convertStatusList(from *statuses) []*scm.Status {
 func convertStatus(from *status) *scm.Status {
 	return &scm.Status{
 		State:  convertState(from.State),
-		Label:  from.Name,
+		Label:  from.Key,
 		Desc:   from.Desc,
 		Target: from.URL,
 	}
@@ -451,4 +501,17 @@ func convertParticipants(participants *participants) []scm.User {
 		answer = append(answer, *convertUser(&p.User))
 	}
 	return answer
+}
+
+func permissionToString(perm string) string {
+	switch perm {
+	case "ADMIN", "PROJECT_ADMIN", "REPO_ADMIN":
+		return scm.AdminPermission
+	case "PROJECT_CREATE", "PROJECT_WRITE", "REPO_WRITE":
+		return scm.WritePermission
+	case "PROJECT_READ", "REPO_READ":
+		return scm.ReadPermission
+	default:
+		return scm.NoPermission
+	}
 }

--- a/scm/driver/stash/testdata/combined_status.json.golden
+++ b/scm/driver/stash/testdata/combined_status.json.golden
@@ -1,0 +1,18 @@
+{
+  "State": "success",
+  "Sha": "b02e90353e4c94cda868dbcdb2301c5691a78b6c",
+  "Statuses": [
+    {
+      "State": "success",
+      "Label": "first-key",
+      "Desc": "This commit looks good.",
+      "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/23/display/redirect"
+    },
+    {
+      "State": "success",
+      "Label": "second-key",
+      "Desc": "This commit looks good.",
+      "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22something/display/redirect"
+    }
+  ]
+}

--- a/scm/driver/stash/testdata/commit_build_status.json
+++ b/scm/driver/stash/testdata/commit_build_status.json
@@ -1,21 +1,29 @@
 {
-  "size": 2,
+  "size": 3,
   "limit": 100,
   "isLastPage": true,
   "values": [
     {
-      "state": "SUCCESSFUL",
-      "key": "new-key",
-      "name": "team-bb-server » repo-1 » master #23",
-      "url": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/21/display/redirect",
-      "description": "This commit looks good.",
+      "state": "FAILED",
+      "key": "first-key",
+      "name": "team-bb-server » repo-1 » master #22",
+      "url": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22/display/redirect",
+      "description": "This commit looks bad.",
       "dateAdded": 1567107583395
     },
     {
       "state": "SUCCESSFUL",
-      "key": "old-key",
-      "name": "team-bb-server » repo-1 » master #22",
-      "url": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22/display/redirect",
+      "key": "second-key",
+      "name": "team-bb-server » repo-1 » master #22 something else",
+      "url": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22something/display/redirect",
+      "description": "This commit looks good.",
+      "dateAdded": 1567087389170
+    },
+    {
+      "state": "SUCCESSFUL",
+      "key": "first-key",
+      "name": "team-bb-server » repo-1 » master #23",
+      "url": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/23/display/redirect",
       "description": "This commit looks good.",
       "dateAdded": 1567087389770
     }

--- a/scm/driver/stash/testdata/commit_build_status.json.golden
+++ b/scm/driver/stash/testdata/commit_build_status.json.golden
@@ -1,14 +1,20 @@
 [
   {
-    "State": "success",
-    "Label": "team-bb-server » repo-1 » master #23",
-    "Desc": "This commit looks good.",
-    "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/21/display/redirect"
+    "State": "failure",
+    "Label": "first-key",
+    "Desc": "This commit looks bad.",
+    "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22/display/redirect"
   },
   {
     "State": "success",
-    "Label": "team-bb-server » repo-1 » master #22",
+    "Label": "second-key",
     "Desc": "This commit looks good.",
-    "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22/display/redirect"
+    "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/22something/display/redirect"
+  },
+  {
+    "State": "success",
+    "Label": "first-key",
+    "Desc": "This commit looks good.",
+    "Target": "http://example.com/master-1/job/kyounger/job/repo-1/job/master/23/display/redirect"
   }
 ]

--- a/scm/driver/stash/testdata/find_user_permission.json
+++ b/scm/driver/stash/testdata/find_user_permission.json
@@ -1,0 +1,20 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "user": {
+        "name": "jcitizen",
+        "emailAddress": "jane@example.com",
+        "id": 101,
+        "displayName": "Jane Citizen",
+        "active": true,
+        "slug": "jcitizen",
+        "type": "NORMAL"
+      },
+      "permission": "REPO_ADMIN"
+    }
+  ],
+  "start": 0
+}


### PR DESCRIPTION
Specifically `RequestReview`, `UnrequestReview`, PR `EditComment`, PR `DeleteComment`, PR `AssignIssue` (falling back on `RequestReview`), PR `UnassignIssue` (falling back on `UnrequestReview`), `FindUserPermission`, `FindCombinedStatus`.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>