### PR TITLE
fix: Add Version to scm.Comment

### DIFF
--- a/scm/driver/stash/pr.go
+++ b/scm/driver/stash/pr.go
@@ -356,6 +356,7 @@ func convertPullRequestComment(from *pullRequestComment) *scm.Comment {
 	return &scm.Comment{
 		ID:      from.ID,
 		Body:    from.Text,
+		Version: from.Version,
 		Created: time.Unix(from.CreatedDate/1000, 0),
 		Updated: time.Unix(from.UpdatedDate/1000, 0),
 		Author: scm.User{

--- a/scm/driver/stash/pr_test.go
+++ b/scm/driver/stash/pr_test.go
@@ -77,7 +77,7 @@ func TestPullDeleteComment(t *testing.T) {
 
 	gock.New("http://example.com:7990").
 		Delete("rest/api/1.0/projects/PRJ/repos/my-repo/pull-requests/1/comments/1").
-		MatchParam("version", "0").
+		MatchParam("version", "5").
 		Reply(204)
 
 	client, _ := New("http://example.com:7990")

--- a/scm/driver/stash/testdata/pr_comment.json
+++ b/scm/driver/stash/testdata/pr_comment.json
@@ -3,7 +3,7 @@
         "repositoryId": 1
     },
     "id": 1,
-    "version": 0,
+    "version": 5,
     "text": "this is a comment",
     "author": {
         "name": "jcitizen",

--- a/scm/driver/stash/testdata/pr_comment.json.golden
+++ b/scm/driver/stash/testdata/pr_comment.json.golden
@@ -7,6 +7,7 @@
         "Email": "jane@example.com",
         "Avatar": "https://www.gravatar.com/avatar/9e26471d35a78862c17e467d87cddedf.jpg"
     },
+    "Version": 5,
     "Created": "2018-07-04T22:58:45-07:00",
     "Updated": "2018-07-04T22:58:45-07:00"
 }

--- a/scm/issue.go
+++ b/scm/issue.go
@@ -56,6 +56,7 @@ type (
 		Body    string
 		Author  User
 		Link    string
+		Version int
 		Created time.Time
 		Updated time.Time
 	}


### PR DESCRIPTION
Since we need this for deleting or editing BitBucket Server comments.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>