### PR TITLE
feat: Implement GitHub create/update of a repository file.

### DIFF
--- a/scm/content.go
+++ b/scm/content.go
@@ -11,6 +11,7 @@ type (
 	Content struct {
 		Path string
 		Data []byte
+		Sha  string
 	}
 
 	// ContentParams provide parameters for creating and
@@ -20,6 +21,7 @@ type (
 		Branch  string
 		Message string
 		Data    []byte
+		Sha     string
 	}
 
 	// FileEntry returns the details of a file

--- a/scm/driver/github/content.go
+++ b/scm/driver/github/content.go
@@ -25,6 +25,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	return &scm.Content{
 		Path: out.Path,
 		Data: raw,
+		Sha:  out.Sha,
 	}, res, err
 }
 
@@ -36,11 +37,26 @@ func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*s
 }
 
 func (s *contentService) Create(ctx context.Context, repo, path string, params *scm.ContentParams) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	endpoint := fmt.Sprintf("repos/%s/contents/%s", repo, path)
+	body := &contentBody{
+		Message: params.Message,
+		Content: params.Data,
+		Branch:  params.Branch,
+	}
+
+	return s.client.do(ctx, "PUT", endpoint, &body, nil)
 }
 
 func (s *contentService) Update(ctx context.Context, repo, path string, params *scm.ContentParams) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	endpoint := fmt.Sprintf("repos/%s/contents/%s", repo, path)
+	body := &contentBody{
+		Message: params.Message,
+		Content: params.Data,
+		Branch:  params.Branch,
+		Sha:     params.Sha,
+	}
+
+	return s.client.do(ctx, "PUT", endpoint, &body, nil)
 }
 
 func (s *contentService) Delete(ctx context.Context, repo, path, ref string) (*scm.Response, error) {
@@ -77,6 +93,13 @@ type contentUpdate struct {
 		Email string    `json:"email"`
 		Date  time.Time `json:"date"`
 	} `json:"committer"`
+}
+
+type contentBody struct {
+	Message string `json:"message"`
+	Content []byte `json:"content"`
+	Sha     string `json:"sha,omitempty"`
+	Branch  string `json:"branch,omitempty"`
 }
 
 func convertEntryList(out []*entry) []*scm.FileEntry {

--- a/scm/driver/github/testdata/content.json.golden
+++ b/scm/driver/github/testdata/content.json.golden
@@ -1,4 +1,5 @@
 {
     "Path": "README",
-    "Data": "SGVsbG8gV29ybGQhCg=="
+    "Data": "SGVsbG8gV29ybGQhCg==",
+    "Sha":  "980a0d5f19a64b4b30a87d4206aade58726b60e3"
 }


### PR DESCRIPTION
This implements creation and updating of files in a GitHub repository.

`scm.Content` has the `Sha` added, because it's needed to do an update, and this saves an extra call to `List` to get it.

This makes it easy to do something like:

```go
content, _, err := client.Contents.Find(
    context.Background(),  "example/repo", "README", "master")

params := &scm.ContentParams{
Branch:  "master",
Message: "Automated update",
Data:    []byte("# Just a test\n"),
Sha:     content.Sha,
}
response, err := client.Contents.Update(
    context.Background(), "example/repo", "README", params)
```