### PR TITLE
feat: Add support for creating new refs in GitHub.

### DIFF
--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -51,6 +51,10 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 	*/
 }
 
+func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }

--- a/scm/driver/fake/git.go
+++ b/scm/driver/fake/git.go
@@ -18,6 +18,10 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 	return f.TestRef, nil, nil
 }
 
+func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
+	panic("implement me")
+}
+
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
 	f := s.data
 	paths := strings.SplitN(repo, "/", 2)

--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -20,6 +20,10 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 	return "", nil, scm.ErrNotSupported
 }
 
+func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }

--- a/scm/driver/github/git.go
+++ b/scm/driver/github/git.go
@@ -43,6 +43,30 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 	return out.Object["sha"], res, err
 }
 
+// CreateRef creates a new ref
+func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
+	path := fmt.Sprintf("repos/%s/git/refs", repo)
+	in := &struct {
+		Ref string `json:"ref"`
+		Sha string `json:"sha"`
+	}{Ref: ref, Sha: sha}
+
+	out := &struct {
+		Ref    string `json:"ref"`
+		Object struct {
+			Sha string
+		} `json:"object"`
+	}{}
+
+	res, err := s.client.do(ctx, http.MethodPost, path, in, out)
+	scmRef := &scm.Reference{
+		Name: out.Ref,
+		Sha:  out.Object.Sha,
+		Path: out.Ref,
+	}
+	return scmRef, res, err
+}
+
 // DeleteRef deletes the given ref
 //
 // See https://developer.github.com/v3/git/refs/#delete-a-reference

--- a/scm/driver/github/testdata/ref.json
+++ b/scm/driver/github/testdata/ref.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/heads/featureA",
+  "node_id": "MDM6UmVmcmVmcy9oZWFkcy9mZWF0dXJlQQ==",
+  "url": "https://api.github.com/repos/octocat/Hello-World/git/refs/heads/featureA",
+  "object": {
+    "type": "commit",
+    "sha": "aa218f56b14c9653891f9e74264a383fa43fefbd",
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/aa218f56b14c9653891f9e74264a383fa43fefbd"
+  }
+}

--- a/scm/driver/github/testdata/ref.json.golden
+++ b/scm/driver/github/testdata/ref.json.golden
@@ -1,0 +1,5 @@
+{
+  "Name": "refs/heads/featureA",
+  "Path": "refs/heads/featureA",
+  "Sha":  "aa218f56b14c9653891f9e74264a383fa43fefbd"
+}

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -40,6 +40,10 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 
 }
 
+func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -20,6 +20,10 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 	return "", nil, scm.ErrNotSupported
 }
 
+func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -39,6 +39,10 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 	return ref, res, err
 }
 
+func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }

--- a/scm/git.go
+++ b/scm/git.go
@@ -84,5 +84,8 @@ type (
 
 		// DeleteRef deletes the given ref
 		DeleteRef(ctx context.Context, repo, ref string) (*Response, error)
+
+		// CreateRef creates a new ref
+		CreateRef(ctx context.Context, repo, ref, sha string) (*Reference, *Response, error)
 	}
 )


### PR DESCRIPTION
This provides functionality for creating new refs, e.g. 

```go
_, response, err := client.Git.CreateRef(
    context.Background(), "demo/repo", "refs/heads/testing", 
    "82291b8e61fa5df765ddb4b3f5cb5f09bdcf4b62")
```