### PR TITLE
feat: Use constant-time comparison for the GitLab token.

### DIFF
--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -5,6 +5,7 @@
 package gitlab
 
 import (
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -56,10 +57,9 @@ func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhoo
 		return hook, nil
 	}
 
-	if token != req.Header.Get("X-Gitlab-Token") {
+	if subtle.ConstantTimeCompare([]byte(req.Header.Get("X-Gitlab-Token")), []byte(token)) == 0 {
 		return hook, scm.ErrSignatureInvalid
 	}
-
 	return hook, nil
 }
 


### PR DESCRIPTION
This changes the GitLab Webhook parsing implementation from a simple (insecure)
string comparison to a more secure constant-time comparison between the token
and the secret.