### PR TITLE
fix: list user private repos

### DIFF
--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -187,9 +187,17 @@ func (s *repositoryService) FindUserPermission(ctx context.Context, repo string,
 
 // List returns the user repository list.
 func (s *repositoryService) List(ctx context.Context, opts scm.ListOptions) ([]*scm.Repository, *scm.Response, error) {
-	path := fmt.Sprintf("user/repos?%s", encodeListOptions(opts))
+	req := &scm.Request{
+		Method: http.MethodGet,
+		Path:   fmt.Sprintf("user/repos?visibility=all&affiliation=owner&%s", encodeListOptions(opts)),
+		Header: map[string][]string{
+			// This accept header enables the visibility parameter.
+			// https://developer.github.com/changes/2019-12-03-internal-visibility-changes/
+			"Accept": {"application/vnd.github.nebula-preview+json"},
+		},
+	}
 	out := []*repository{}
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	res, err := s.client.doRequest(ctx, req, nil, &out)
 	return convertRepositoryList(out), res, err
 }
 


### PR DESCRIPTION
fixes https://github.com/jenkins-x/go-scm/issues/147

Current behaviour:
repositoryService.List returns the list of all public repos user has access to accross all organizations.

Desired behaviour:
This List method now returns the list of all repos on which the user is a owner.
In case we have a token in the header of the request, it will return both public and private. If we don't have a token it will return public only.

Open question:
I'm not sure this is the best place to achieve that or if I should update the ListUser method here: https://github.com/jenkins-x/go-scm/compare/master...romainverduci:list-user-private-repos?expand=1#diff-2a18725c234b64fe3425404bfbe3abd3R213
The requirement is that I need a way to get the list of public and private repos for a given user authenticated by its token. The same list that is in https://github.com/romainverduci for example.