### PR TITLE
fix: github: add sha parameter for listing commits

### DIFF
--- a/scm/driver/github/integration/git_test.go
+++ b/scm/driver/github/integration/git_test.go
@@ -115,6 +115,7 @@ func testCommits(client *scm.Client) func(t *testing.T) {
 		t.Parallel()
 		t.Run("Find", testCommitFind(client))
 		t.Run("List", testCommitList(client))
+		t.Run("BranchList", testBranchCommitList(client))
 	}
 }
 
@@ -148,6 +149,27 @@ func testCommitList(client *scm.Client) func(t *testing.T) {
 			if commit.Sha == "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d" {
 				t.Run("Commit", testCommit(commit))
 			}
+		}
+	}
+}
+
+func testBranchCommitList(client *scm.Client) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		opts := scm.CommitListOptions{
+			Sha: "test",
+		}
+		result, _, err := client.Git.ListCommits(context.Background(), "octocat/Hello-World", opts)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(result) == 0 {
+			t.Errorf("Want a non-empty commit list")
+		}
+
+		if result[0].Sha != "b3cbd5bbd7e81436d2eee04537ea2b4c0cad4cdf" {
+			t.Errorf("Unexpected commit")
 		}
 	}
 }

--- a/scm/driver/github/util.go
+++ b/scm/driver/github/util.go
@@ -40,6 +40,9 @@ func encodeCommitListOptions(opts scm.CommitListOptions) string {
 	if opts.Ref != "" {
 		params.Set("ref", opts.Ref)
 	}
+	if opts.Sha != "" {
+		params.Set("sha", opts.Sha)
+	}
 	return params.Encode()
 }
 

--- a/scm/example_test.go
+++ b/scm/example_test.go
@@ -197,6 +197,28 @@ func ExampleCommit_list() {
 	}
 }
 
+func ExampleBranchCommit_list() {
+	client, err := github.New("https://api.github.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	opts := scm.CommitListOptions{
+		Sha:  "test",
+		Page: 1,
+		Size: 30,
+	}
+
+	commits, _, err := client.Git.ListCommits(ctx, "octocat/Hello-World", opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, commit := range commits {
+		log.Println(commit.Sha, commit.Message, commit.Author.Login)
+	}
+}
+
 func ExampleCommit_changes() {
 	client, err := github.New("https://api.github.com")
 	if err != nil {

--- a/scm/git.go
+++ b/scm/git.go
@@ -40,6 +40,7 @@ type (
 	// list of repository commits.
 	CommitListOptions struct {
 		Ref  string
+		Sha  string
 		Page int
 		Size int
 	}


### PR DESCRIPTION
Hey,

According to the docs (see reference), the `sha` parameter should be
used to list commits of a specific branch.

Reference:
- https://developer.github.com/v3/repos/commits/#list-commits

Thanks!