### PR TITLE
feat: Automatically identify the driver from a URL.

### DIFF
--- a/scm/factory/drivers.go
+++ b/scm/factory/drivers.go
@@ -1,0 +1,59 @@
+package factory
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// HostDriverIdentifier is a mapping of hostname to scm driver.
+type HostDriverIdentifier map[string]string
+
+// Identify looks up the provided hostname, and returns the driver mapping.
+//
+// If no mapping exists, then it returns an error.
+func (u HostDriverIdentifier) Identify(host string) (string, error) {
+	d, ok := u[host]
+	if ok {
+		return d, nil
+	}
+	return "", unknownDriverError{hostname: host}
+}
+
+// MappingFunc is a type for adding names to the list of mappings from hosts to
+// drivers.
+type MappingFunc func(HostDriverIdentifier)
+
+// Mapping adds a host,driver combination to the DriverIdentifier.
+func Mapping(host, driver string) MappingFunc {
+	return func(m HostDriverIdentifier) {
+		m[host] = driver
+	}
+}
+
+// NewDriverIdentifier creates and returns a new HostDriverIdentifier.
+func NewDriverIdentifier(extras ...MappingFunc) HostDriverIdentifier {
+	u := HostDriverIdentifier{
+		"github.com": "github",
+		"gitlab.com": "gitlab",
+	}
+	for _, e := range extras {
+		e(u)
+	}
+	e := os.Getenv("GIT_DRIVERS")
+	for _, v := range strings.Split(e, ",") {
+		parts := strings.Split(v, "=")
+		if len(parts) == 2 {
+			u[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return u
+}
+
+type unknownDriverError struct {
+	hostname string
+}
+
+func (e unknownDriverError) Error() string {
+	return fmt.Sprintf("unable to identify driver from hostname: %s", e.hostname)
+}

--- a/scm/factory/drivers_test.go
+++ b/scm/factory/drivers_test.go
@@ -1,0 +1,68 @@
+package factory
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestIdentify(t *testing.T) {
+	urlTests := []struct {
+		name     string
+		hostname string
+		want     string
+		envVar   string
+		wantErr  string
+	}{
+		{"simple github", "github.com", "github", "", ""},
+		{"simple gitlab", "gitlab.com", "gitlab", "", ""},
+		{"from environment mapping", "gl.example.com", "gitlab", "gl.example.com=gitlab,gh.github.com=github", ""},
+		{"unknown host", "scm.example.com", "", "", "unable to identify driver"},
+	}
+	origEnv := os.Getenv("GIT_DRIVERS")
+	defer func() {
+		os.Setenv("GIT_DRIVERS", origEnv)
+	}()
+
+	for _, tt := range urlTests {
+		t.Run(tt.hostname, func(rt *testing.T) {
+			if tt.envVar != "" {
+				os.Setenv("GIT_DRIVERS", tt.envVar)
+			}
+			identifier := NewDriverIdentifier()
+			driver, err := identifier.Identify(tt.hostname)
+			if !matchError(rt, tt.wantErr, err) {
+				rt.Errorf("error failed to match, got %#v, want %s", err, tt.wantErr)
+			}
+			if driver != tt.want {
+				rt.Errorf("got %s, want %s", driver, tt.want)
+			}
+		})
+	}
+}
+
+func TestIdentifyWithExtras(t *testing.T) {
+	identifier := NewDriverIdentifier(Mapping("test.example.com", "gitlab"))
+	driver, err := identifier.Identify("test.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if driver != "gitlab" {
+		t.Fatalf("got %q, want %q", driver, "gitlab")
+	}
+}
+
+func matchError(t *testing.T, s string, e error) bool {
+	t.Helper()
+	if s == "" && e == nil {
+		return true
+	}
+	if s != "" && e == nil {
+		return false
+	}
+	match, err := regexp.MatchString(s, e.Error())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return match
+}

--- a/scm/factory/factory.go
+++ b/scm/factory/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -21,6 +22,9 @@ import (
 
 // MissingGitServerURL the error returned if you use a git driver that needs a git server URL
 var MissingGitServerURL = fmt.Errorf("No git serverURL was specified")
+
+// DefaultIdentifier is the default driver identifier used by FromRepoURL.
+var DefaultIdentifier = NewDriverIdentifier()
 
 type clientOptionFunc func(*scm.Client)
 
@@ -97,6 +101,9 @@ func NewClient(driver, serverURL, oauthToken string, opts ...clientOptionFunc) (
 // NewClientFromEnvironment creates a new client using environment variables $GIT_KIND, $GIT_SERVER, $GIT_TOKEN
 // defaulting to github if no $GIT_KIND or $GIT_SERVER
 func NewClientFromEnvironment() (*scm.Client, error) {
+	if repoURL := os.Getenv("GIT_REPO_URL"); repoURL != "" {
+		return FromRepoURL(repoURL)
+	}
 	driver := os.Getenv("GIT_KIND")
 	serverURL := os.Getenv("GIT_SERVER")
 	oauthToken := os.Getenv("GIT_TOKEN")
@@ -111,13 +118,34 @@ func NewClientFromEnvironment() (*scm.Client, error) {
 	return client, err
 }
 
+// FromRepoURL parses a URL of the form https://:authtoken@host/ and attempts to
+// determine the driver and creates a client to authenticate to the endpoint.
+func FromRepoURL(repoURL string) (*scm.Client, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return nil, err
+	}
+	auth := ""
+	if password, ok := u.User.Password(); ok {
+		auth = password
+	}
+
+	driver, err := DefaultIdentifier.Identify(u.Host)
+	if err != nil {
+		return nil, err
+	}
+	u.Path = "/"
+	u.User = nil
+	return NewClient(driver, u.String(), auth)
+}
+
 // ensureGHEEndpoint lets ensure we have the /api/v3 suffix on the URL
 func ensureGHEEndpoint(u string) string {
 	if strings.HasPrefix(u, "https://github.com") || strings.HasPrefix(u, "http://github.com") {
 		return "https://api.github.com"
 	}
 	// lets ensure we use the API endpoint to login
-	if strings.Index(u, "/api/") < 0 {
+	if !strings.Contains(u, "/api/") {
 		u = scm.UrlJoin(u, "/api/v3")
 	}
 	return u

--- a/scm/factory/factory_test.go
+++ b/scm/factory/factory_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/jenkins-x/go-scm/scm"
+	"github.com/jenkins-x/go-scm/scm/transport"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,4 +33,20 @@ func TestNewClientWithOptionFunc(t *testing.T) {
 	}
 
 	assert.Equal(t, scmClient.Client, httpClient)
+}
+
+func TestFromRepoURL(t *testing.T) {
+	client, err := FromRepoURL("https://:abc123@gitlab.com/myorg/myrepo.git")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client.BaseURL.String() != "https://gitlab.com/" {
+		t.Fatalf("BaseURL got %q, want %q", client.BaseURL, "https://gitlab.com/")
+	}
+	if client.Driver != scm.DriverGitlab {
+		t.Fatalf("Driver got %q, want %q", client.Driver, client.Driver)
+	}
+	if p := client.Client.Transport.(*transport.PrivateToken).Token; p != "abc123" {
+		t.Fatalf("got %q, want %q", p, "abc123")
+	}
 }


### PR DESCRIPTION
In addition, the function `factory.FromRepoURL(s string)` accepts a string of the
form "https://:password@hostname/" can be used to create a client from
the URL, determining the auth token, endpoint and driver automatically
(if possible).

This adds functionality for identifying the driver for an scm.Client
from a hostname, including customising this from the environment
variable `GIT_DRIVERS`.

Putting a list of the form "gl.example.com=gitlab,gh.example.com=github"
into the `GIT_DRIVERS` environment variable provides a way to add
additional hostname to driver mappings.

```go
// works for public repos on GitHub.com
client, err := factory.FromRepoURL("https://github.com")
```

```go
// export GIT_REPO_URL=https://:<insert token>@github.com/ works
client, err := factory.NewClientFromEnvironment()
```