### PR TITLE
feat: Adding GraphQL for gitlab

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/h2non/gock v1.0.9
 	github.com/pkg/errors v0.8.1
 	github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260
-	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
+	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
 	github.com/sirupsen/logrus v1.4.2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45


### PR DESCRIPTION
-  Adds a generic GraphQL client on gitlab driver (github.com/shurcooL/graphql)