### PR TITLE
fix: for GitHub Enterprise

### DIFF
--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -252,9 +252,9 @@ func (s *repositoryService) ListLabels(ctx context.Context, repo string, opts sc
 
 // Create creates a new repository
 func (s *repositoryService) Create(ctx context.Context, input *scm.RepositoryInput) (*scm.Repository, *scm.Response, error) {
-	path := "/user/repos"
+	path := "user/repos"
 	if input.Namespace != "" {
-		path = fmt.Sprintf("/orgs/%s/repos", input.Namespace)
+		path = fmt.Sprintf("orgs/%s/repos", input.Namespace)
 
 	}
 	in := new(repositoryInput)
@@ -272,7 +272,7 @@ type forkInput struct {
 }
 
 func (s *repositoryService) Fork(ctx context.Context, input *scm.RepositoryInput, origRepo string) (*scm.Repository, *scm.Response, error) {
-	path := fmt.Sprintf("/repos/%s/forks", origRepo)
+	path := fmt.Sprintf("repos/%s/forks", origRepo)
 
 	in := new(forkInput)
 	if input.Namespace != "" {


### PR DESCRIPTION
we need to use relative links rather than absolute as on GitHub Enterprise the client URL includes things like `/api/v3/` prefix which we need to preserve

Signed-off-by: jstrachan <jenkins-x@googlegroups.com>