### PR TITLE
feat: Switch Gitea to use Gitea's go-sdk client behind the scenes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/jenkins-x/go-scm
 
 require (
+	code.gitea.io/sdk/gitea v0.12.1
+	github.com/bluekeyes/go-gitdiff v0.4.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.0
 	github.com/h2non/gock v1.0.9
@@ -8,7 +10,7 @@ require (
 	github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
 	github.com/sirupsen/logrus v1.4.2
-	github.com/stretchr/testify v1.3.0
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	k8s.io/apimachinery v0.0.0-20190703205208-4cfb76a8bf76
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,9 @@
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+code.gitea.io/sdk v0.11.0 h1:R3VdjBCxObyLKnv4Svd/TM6oGsXzN8JORbzgkEFb83w=
+code.gitea.io/sdk/gitea v0.12.1 h1:bMgjEqPnNX/i6TpVwXwpjJtFOnUSuC9P6yy/jjy8sjY=
+code.gitea.io/sdk/gitea v0.12.1/go.mod h1:z3uwDV/b9Ls47NGukYM9XhnHtqPh/J+t40lsUrR6JDY=
+github.com/bluekeyes/go-gitdiff v0.4.0 h1:Q3qUnQ5cv27vG6ywUTiSQUobRYRcQIBs8KVGKojLg9I=
+github.com/bluekeyes/go-gitdiff v0.4.0/go.mod h1:QpfYYO1E0fTVHVZAZKiRjtSGY9823iCdvGXBcEzHGbM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -20,6 +25,8 @@ github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/h2non/gock v1.0.9 h1:17gCehSo8ZOgEsFKpQgqHiR7VLyjxdAG3lkhVvO9QZU=
 github.com/h2non/gock v1.0.9/go.mod h1:CZMcB0Lg5IWnr9bF79pPMg9WeV6WumxQiUJ1UvdO1iE=
+github.com/hashicorp/go-version v1.2.0 h1:3vNe/fWF5CBgRIguda1meWhsZHy3m8gCJ5wx+dIzX/E=
+github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -49,6 +56,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/scm/driver/gitea/content.go
+++ b/scm/driver/gitea/content.go
@@ -5,9 +5,7 @@
 package gitea
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -18,15 +16,16 @@ type contentService struct {
 }
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
+	namespace, name := scm.Split(repo)
+
 	ref = strings.TrimPrefix(ref, "refs/heads/")
 	ref = strings.TrimPrefix(ref, "refs/tags/")
-	endpoint := fmt.Sprintf("api/v1/repos/%s/raw/%s/%s", repo, ref, path)
-	buf := new(bytes.Buffer)
-	res, err := s.client.do(ctx, "GET", endpoint, nil, buf)
+
+	out, err := s.client.GiteaClient.GetFile(namespace, name, ref, path)
 	return &scm.Content{
 		Path: path,
-		Data: buf.Bytes(),
-	}, res, err
+		Data: out,
+	}, nil, err
 }
 
 func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {

--- a/scm/driver/gitea/issue.go
+++ b/scm/driver/gitea/issue.go
@@ -5,11 +5,25 @@
 package gitea
 
 import (
+	"code.gitea.io/sdk/gitea"
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"time"
 
 	"github.com/jenkins-x/go-scm/scm"
+)
+
+type stateType string
+
+const (
+	// stateOpen pr/issue is opend
+	stateOpen stateType = "open"
+	// stateClosed pr/issue is closed
+	stateClosed stateType = "closed"
+	// stateAll is all
+	stateAll stateType = "all"
 )
 
 type issueService struct {
@@ -22,90 +36,197 @@ func (s *issueService) Search(context.Context, scm.SearchOptions) ([]*scm.Search
 }
 
 func (s *issueService) AssignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	issue, res, err := s.Find(ctx, repo, number)
+	if err != nil {
+		return res, errors.Wrapf(err, "couldn't lookup issue %d in repository %s", number, repo)
+	}
+	if issue == nil {
+		return res, fmt.Errorf("couldn't find issue %d in repository %s", number, repo)
+	}
+	assignees := sets.NewString(logins...)
+	for _, existingAssignee := range issue.Assignees {
+		assignees.Insert(existingAssignee.Login)
+	}
+
+	namespace, name := scm.Split(repo)
+	in := gitea.EditIssueOption{
+		Title:     issue.Title,
+		Assignees: assignees.List(),
+	}
+	_, err = s.client.GiteaClient.EditIssue(namespace, name, int64(number), in)
+	return nil, err
 }
 
 func (s *issueService) UnassignIssue(ctx context.Context, repo string, number int, logins []string) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	issue, res, err := s.Find(ctx, repo, number)
+	if err != nil {
+		return res, errors.Wrapf(err, "couldn't lookup issue %d in repository %s", number, repo)
+	}
+	if issue == nil {
+		return res, fmt.Errorf("couldn't find issue %d in repository %s", number, repo)
+	}
+	assignees := sets.NewString()
+	for _, existingAssignee := range issue.Assignees {
+		assignees.Insert(existingAssignee.Login)
+	}
+	assignees.Delete(logins...)
+
+	namespace, name := scm.Split(repo)
+	in := gitea.EditIssueOption{
+		Title:     issue.Title,
+		Assignees: assignees.List(),
+	}
+	_, err = s.client.GiteaClient.EditIssue(namespace, name, int64(number), in)
+	return nil, err
 }
 
 func (s *issueService) ListEvents(context.Context, string, int, scm.ListOptions) ([]*scm.ListedIssueEvent, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 
-func (s *issueService) ListLabels(context.Context, string, int, scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+func (s *issueService) ListLabels(ctx context.Context, repo string, number int, _ scm.ListOptions) ([]*scm.Label, *scm.Response, error) {
+	namespace, name := scm.Split(repo)
+	out, err := s.client.GiteaClient.GetIssueLabels(namespace, name, int64(number), gitea.ListLabelsOptions{})
+	return convertGiteaLabels(out), nil, err
 }
 
-func (s *issueService) AddLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+func (s *issueService) lookupLabel(ctx context.Context, repo string, lbl string) (int64, *scm.Response, error) {
+	var labelID int64
+	labelID = -1
+	repoLabels, res, err := s.client.Repositories.ListLabels(ctx, repo, scm.ListOptions{})
+	if err != nil {
+		return labelID, res, errors.Wrapf(err, "listing labels in repository %s", repo)
+	}
+	for _, l := range repoLabels {
+		if l.Name == lbl {
+			labelID = l.ID
+			break
+		}
+	}
+	return labelID, res, nil
 }
 
-func (s *issueService) DeleteLabel(ctx context.Context, repo string, number int, label string) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+func (s *issueService) AddLabel(ctx context.Context, repo string, number int, lbl string) (*scm.Response, error) {
+	labelID, res, err := s.lookupLabel(ctx, repo, lbl)
+	if err != nil {
+		return res, err
+	}
+	namespace, name := scm.Split(repo)
+
+	if labelID == -1 {
+		lblInput := gitea.CreateLabelOption{
+			Color:       "#00aabb",
+			Description: "",
+			Name:        lbl,
+		}
+		newLabel, err := s.client.GiteaClient.CreateLabel(namespace, name, lblInput)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to create label %s in repository %s", lbl, repo)
+		}
+		labelID = newLabel.ID
+	}
+
+	in := gitea.IssueLabelsOption{Labels: []int64{labelID}}
+	_, err = s.client.GiteaClient.AddIssueLabels(namespace, name, int64(number), in)
+	return nil, err
+}
+
+func (s *issueService) DeleteLabel(ctx context.Context, repo string, number int, lbl string) (*scm.Response, error) {
+	labelID, res, err := s.lookupLabel(ctx, repo, lbl)
+	if err != nil {
+		return res, err
+	}
+	if labelID == -1 {
+		return nil, nil
+	}
+
+	namespace, name := scm.Split(repo)
+	err = s.client.GiteaClient.DeleteIssueLabel(namespace, name, int64(number), labelID)
+	return nil, err
 }
 
 func (s *issueService) Find(ctx context.Context, repo string, number int) (*scm.Issue, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues/%d", repo, number)
-	out := new(issue)
-	res, err := s.client.do(ctx, "GET", path, nil, out)
-	return convertIssue(out), res, err
+	namespace, name := scm.Split(repo)
+	out, err := s.client.GiteaClient.GetIssue(namespace, name, int64(number))
+	return convertGiteaIssue(out), nil, err
 }
 
 func (s *issueService) FindComment(ctx context.Context, repo string, index, id int) (*scm.Comment, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+	comments, res, err := s.ListComments(ctx, repo, index, scm.ListOptions{})
+	if err != nil {
+		return nil, res, err
+	}
+	for _, comment := range comments {
+		if comment.ID == id {
+			return comment, res, nil
+		}
+	}
+	return nil, res, nil
 }
 
 func (s *issueService) List(ctx context.Context, repo string, _ scm.IssueListOptions) ([]*scm.Issue, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues", repo)
-	out := []*issue{}
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	return convertIssueList(out), res, err
+	namespace, name := scm.Split(repo)
+	in := gitea.ListIssueOption{
+		Type: gitea.IssueTypeIssue,
+	}
+	out, err := s.client.GiteaClient.ListRepoIssues(namespace, name, in)
+	return convertIssueList(out), nil, err
 }
 
 func (s *issueService) ListComments(ctx context.Context, repo string, index int, _ scm.ListOptions) ([]*scm.Comment, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues/%d/comments", repo, index)
-	out := []*issueComment{}
-	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	return convertIssueCommentList(out), res, err
+	namespace, name := scm.Split(repo)
+	out, err := s.client.GiteaClient.ListIssueComments(namespace, name, int64(index), gitea.ListIssueCommentOptions{})
+	return convertIssueCommentList(out), nil, err
 }
 
 func (s *issueService) Create(ctx context.Context, repo string, input *scm.IssueInput) (*scm.Issue, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues", repo)
-	in := &issueInput{
+	namespace, name := scm.Split(repo)
+
+	in := gitea.CreateIssueOption{
 		Title: input.Title,
 		Body:  input.Body,
 	}
-	out := new(issue)
-	res, err := s.client.do(ctx, "POST", path, in, out)
-	return convertIssue(out), res, err
+	out, err := s.client.GiteaClient.CreateIssue(namespace, name, in)
+	return convertGiteaIssue(out), nil, err
 }
 
 func (s *issueService) CreateComment(ctx context.Context, repo string, index int, input *scm.CommentInput) (*scm.Comment, *scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues/%d/comments", repo, index)
-	in := &issueCommentInput{
-		Body: input.Body,
-	}
-	out := new(issueComment)
-	res, err := s.client.do(ctx, "POST", path, in, out)
-	return convertIssueComment(out), res, err
+	namespace, name := scm.Split(repo)
+	in := gitea.CreateIssueCommentOption{Body: input.Body}
+	out, err := s.client.GiteaClient.CreateIssueComment(namespace, name, int64(index), in)
+	return convertGiteaIssueComment(out), nil, err
 }
 
 func (s *issueService) DeleteComment(ctx context.Context, repo string, index, id int) (*scm.Response, error) {
-	path := fmt.Sprintf("api/v1/repos/%s/issues/%d/comments/%d", repo, index, id)
-	return s.client.do(ctx, "DELETE", path, nil, nil)
+	namespace, name := scm.Split(repo)
+	return nil, s.client.GiteaClient.DeleteIssueComment(namespace, name, int64(id))
 }
 
 func (s *issueService) EditComment(ctx context.Context, repo string, number int, id int, input *scm.CommentInput) (*scm.Comment, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+	namespace, name := scm.Split(repo)
+	in := gitea.EditIssueCommentOption{Body: input.Body}
+	out, err := s.client.GiteaClient.EditIssueComment(namespace, name, int64(id), in)
+	return convertGiteaIssueComment(out), nil, err
 }
 
 func (s *issueService) Close(ctx context.Context, repo string, number int) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	namespace, name := scm.Split(repo)
+	closed := gitea.StateClosed
+	in := gitea.EditIssueOption{
+		State: &closed,
+	}
+	_, err := s.client.GiteaClient.EditIssue(namespace, name, int64(number), in)
+	return nil, err
 }
 
 func (s *issueService) Reopen(ctx context.Context, repo string, number int) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	namespace, name := scm.Split(repo)
+	reopen := gitea.StateOpen
+	in := gitea.EditIssueOption{
+		State: &reopen,
+	}
+	_, err := s.client.GiteaClient.EditIssue(namespace, name, int64(number), in)
+	return nil, err
 }
 
 func (s *issueService) Lock(ctx context.Context, repo string, number int) (*scm.Response, error) {
@@ -120,6 +241,19 @@ func (s *issueService) Unlock(ctx context.Context, repo string, number int) (*sc
 // native data structures
 //
 
+type label struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	// example: 00aabb
+	Color       string `json:"color"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
+type closeReopenInput struct {
+	State stateType `json:"state"`
+}
+
 type (
 	// gitea issue response object.
 	issue struct {
@@ -128,21 +262,16 @@ type (
 		User        user      `json:"user"`
 		Title       string    `json:"title"`
 		Body        string    `json:"body"`
-		State       string    `json:"state"`
-		Labels      []string  `json:"labels"`
+		State       stateType `json:"state"`
+		Labels      []label   `json:"labels"`
 		Comments    int       `json:"comments"`
+		Assignees   []user    `json:"assignees"`
 		Created     time.Time `json:"created_at"`
 		Updated     time.Time `json:"updated_at"`
 		PullRequest *struct {
 			Merged   bool        `json:"merged"`
 			MergedAt interface{} `json:"merged_at"`
 		} `json:"pull_request"`
-	}
-
-	// gitea issue request object.
-	issueInput struct {
-		Title string `json:"title"`
-		Body  string `json:"body"`
 	}
 
 	// gitea issue comment response object.
@@ -154,44 +283,48 @@ type (
 		CreatedAt time.Time `json:"created_at"`
 		UpdatedAt time.Time `json:"updated_at"`
 	}
-
-	// gitea issue comment request object.
-	issueCommentInput struct {
-		Body string `json:"body"`
-	}
 )
 
 //
 // native data structure conversion
 //
 
-func convertIssueList(from []*issue) []*scm.Issue {
-	to := []*scm.Issue{}
-	for _, v := range from {
-		to = append(to, convertIssue(v))
-	}
-	return to
-}
-
 func convertIssue(from *issue) *scm.Issue {
 	return &scm.Issue{
-		Number:  from.Number,
-		Title:   from.Title,
-		Body:    from.Body,
-		Link:    "", // TODO construct the link to the issue.
-		Closed:  from.State == "closed",
-		Author:  *convertUser(&from.User),
-		Created: from.Created,
-		Updated: from.Updated,
+		Number:    from.Number,
+		Title:     from.Title,
+		Body:      from.Body,
+		Link:      "", // TODO construct the link to the issue.
+		Closed:    from.State == "closed",
+		Labels:    convertLabels(from),
+		Author:    *convertUser(&from.User),
+		Assignees: convertUsers(from.Assignees),
+		Created:   from.Created,
+		Updated:   from.Updated,
 	}
 }
 
-func convertIssueCommentList(from []*issueComment) []*scm.Comment {
-	to := []*scm.Comment{}
+func convertIssueList(from []*gitea.Issue) []*scm.Issue {
+	to := []*scm.Issue{}
 	for _, v := range from {
-		to = append(to, convertIssueComment(v))
+		to = append(to, convertGiteaIssue(v))
 	}
 	return to
+}
+
+func convertGiteaIssue(from *gitea.Issue) *scm.Issue {
+	return &scm.Issue{
+		Number:    int(from.Index),
+		Title:     from.Title,
+		Body:      from.Body,
+		Link:      from.URL,
+		Closed:    from.State == gitea.StateClosed,
+		Labels:    convertIssueLabels(from),
+		Author:    *convertGiteaUser(from.Poster),
+		Assignees: convertGiteaUsers(from.Assignees),
+		Created:   from.Created,
+		Updated:   from.Updated,
+	}
 }
 
 func convertIssueComment(from *issueComment) *scm.Comment {
@@ -202,4 +335,54 @@ func convertIssueComment(from *issueComment) *scm.Comment {
 		Created: from.CreatedAt,
 		Updated: from.UpdatedAt,
 	}
+}
+
+func convertIssueCommentList(from []*gitea.Comment) []*scm.Comment {
+	to := []*scm.Comment{}
+	for _, v := range from {
+		to = append(to, convertGiteaIssueComment(v))
+	}
+	return to
+}
+
+func convertGiteaIssueComment(from *gitea.Comment) *scm.Comment {
+	if from == nil || from.Poster == nil {
+		return nil
+	}
+	return &scm.Comment{
+		ID:      int(from.ID),
+		Body:    from.Body,
+		Author:  *convertGiteaUser(from.Poster),
+		Created: from.Created,
+		Updated: from.Updated,
+	}
+}
+
+func convertLabels(from *issue) []string {
+	var labels []string
+	for _, label := range from.Labels {
+		labels = append(labels, label.Name)
+	}
+	return labels
+}
+
+func convertIssueLabels(from *gitea.Issue) []string {
+	var labels []string
+	for _, label := range from.Labels {
+		labels = append(labels, label.Name)
+	}
+	return labels
+}
+
+func convertGiteaLabels(from []*gitea.Label) []*scm.Label {
+	var labels []*scm.Label
+	for _, label := range from {
+		labels = append(labels, &scm.Label{
+			Name:        label.Name,
+			Description: label.Description,
+			URL:         label.URL,
+			Color:       label.Color,
+		})
+	}
+	return labels
 }

--- a/scm/driver/gitea/repo_test.go
+++ b/scm/driver/gitea/repo_test.go
@@ -106,7 +106,7 @@ func TestRepoNotFound(t *testing.T) {
 	_, _, err := client.Repositories.FindPerms(context.Background(), "gogits/go-gogs-client")
 	if err == nil {
 		t.Errorf("Expect Not Found error")
-	} else if got, want := err.Error(), "Not Found"; got != want {
+	} else if got, want := err.Error(), "404 Not Found"; got != want {
 		t.Errorf("Want error %q, got %q", want, got)
 	}
 }
@@ -264,7 +264,7 @@ func TestHookEvents(t *testing.T) {
 func TestStatusList(t *testing.T) {
 	defer gock.Off()
 	gock.New("https://try.gitea.io").
-		Get("/api/v1/repos/jcitizen/my-repo/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e").
+		Get("/api/v1/repos/jcitizen/my-repo/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/statuses").
 		Reply(200).
 		Type("application/json").
 		File("testdata/statuses.json")

--- a/scm/driver/gitea/testdata/assign_issue.json
+++ b/scm/driver/gitea/testdata/assign_issue.json
@@ -1,0 +1,9 @@
+{
+  "title":"Bug found",
+  "body":null,
+  "assignee":null,
+  "assignees":["a","b","string"],
+  "milestone":null,
+  "state":null,
+  "due_date":null
+}

--- a/scm/driver/gitea/testdata/close_issue.json
+++ b/scm/driver/gitea/testdata/close_issue.json
@@ -1,0 +1,9 @@
+{
+  "title":"",
+  "body":null,
+  "assignee":null,
+  "assignees":null,
+  "milestone":null,
+  "state":"closed",
+  "due_date":null
+}

--- a/scm/driver/gitea/testdata/close_pr.json
+++ b/scm/driver/gitea/testdata/close_pr.json
@@ -1,0 +1,11 @@
+{
+  "title":"",
+  "body":"",
+  "base": "",
+  "assignee":"",
+  "assignees": null,
+  "labels": null,
+  "milestone":0,
+  "state":"closed",
+  "due_date": null
+}

--- a/scm/driver/gitea/testdata/comment.json
+++ b/scm/driver/gitea/testdata/comment.json
@@ -2,7 +2,7 @@
     "id": 74,
     "user": {
         "id": 1,
-        "username": "unknwon",
+        "login": "unknwon",
         "full_name": "无闻",
         "email": "u@gogs.io",
         "avatar_url": "http://localhost:3000/avatars/1"

--- a/scm/driver/gitea/testdata/comment.json.golden
+++ b/scm/driver/gitea/testdata/comment.json.golden
@@ -2,6 +2,7 @@
     "ID": 74,
     "Body": "what?",
     "Author": {
+        "ID": 1,
         "Login": "unknwon",
         "Name": "无闻",
         "Email": "u@gogs.io",

--- a/scm/driver/gitea/testdata/comments.json
+++ b/scm/driver/gitea/testdata/comments.json
@@ -3,7 +3,7 @@
     "id": 74,
     "user": {
       "id": 1,
-      "username": "unknwon",
+      "login": "unknwon",
       "full_name": "无闻",
       "email": "u@gogs.io",
       "avatar_url": "http://localhost:3000/avatars/1"

--- a/scm/driver/gitea/testdata/comments.json.golden
+++ b/scm/driver/gitea/testdata/comments.json.golden
@@ -3,6 +3,7 @@
         "ID": 74,
         "Body": "what?",
         "Author": {
+            "ID": 1,
             "Login": "unknwon",
             "Name": "无闻",
             "Email": "u@gogs.io",

--- a/scm/driver/gitea/testdata/issue.json
+++ b/scm/driver/gitea/testdata/issue.json
@@ -13,10 +13,28 @@
   "title": "Bug found",
   "body": "I'm having a problem with this.",
   "labels": [
-    
+    {
+      "color": "00aabb",
+      "description": "string",
+      "id": 0,
+      "name": "string",
+      "url": "string"
+    }
   ],
   "milestone": null,
-  "assignee": null,
+  "assignees": [
+    {
+      "avatar_url": "string",
+      "created": "2020-09-01T14:36:49.343Z",
+      "email": "user@example.com",
+      "full_name": "string",
+      "id": 0,
+      "is_admin": true,
+      "language": "string",
+      "last_login": "2020-09-01T14:36:49.343Z",
+      "login": "string"
+    }
+  ],
   "state": "open",
   "comments": 0,
   "created_at": "2017-09-23T19:24:01Z",

--- a/scm/driver/gitea/testdata/issue.json.golden
+++ b/scm/driver/gitea/testdata/issue.json.golden
@@ -3,10 +3,21 @@
     "Title": "Bug found",
     "Body": "I'm having a problem with this.",
     "Link": "",
-    "Labels": null,
+    "Labels": [
+        "string"
+    ],
+    "Assignees": [
+        {
+            "Login": "string",
+            "Name": "string",
+            "Email": "user@example.com",
+            "Avatar": "string"
+        }
+    ],
     "Closed": false,
     "Locked": false,
     "Author": {
+        "ID": 1,
         "Login": "janedoe",
         "Name": "",
         "Email": "janedoe@mail.com",

--- a/scm/driver/gitea/testdata/issue_labels.json
+++ b/scm/driver/gitea/testdata/issue_labels.json
@@ -1,0 +1,9 @@
+[
+  {
+    "color": "00aabb",
+    "description": "string",
+    "id": 0,
+    "name": "string",
+    "url": "string"
+  }
+]

--- a/scm/driver/gitea/testdata/issue_labels.json.golden
+++ b/scm/driver/gitea/testdata/issue_labels.json.golden
@@ -1,0 +1,9 @@
+[
+  {
+    "color": "00aabb",
+    "description": "string",
+    "id": 0,
+    "name": "string",
+    "url": "string"
+  }
+]

--- a/scm/driver/gitea/testdata/issues.json
+++ b/scm/driver/gitea/testdata/issues.json
@@ -13,7 +13,13 @@
     "title": "Bug found",
     "body": "I'm having a problem with this.",
     "labels": [
-      
+      {
+        "color": "00aabb",
+        "description": "string",
+        "id": 0,
+        "name": "string",
+        "url": "string"
+      }
     ],
     "milestone": null,
     "assignee": null,

--- a/scm/driver/gitea/testdata/issues.json.golden
+++ b/scm/driver/gitea/testdata/issues.json.golden
@@ -4,10 +4,13 @@
         "Title": "Bug found",
         "Body": "I'm having a problem with this.",
         "Link": "",
-        "Labels": null,
+        "Labels": [
+            "string"
+        ],
         "Closed": false,
         "Locked": false,
         "Author": {
+            "ID": 1,
             "Login": "janedoe",
             "Name": "",
             "Email": "janedoe@mail.com",

--- a/scm/driver/gitea/testdata/pr.json.golden
+++ b/scm/driver/gitea/testdata/pr.json.golden
@@ -6,11 +6,47 @@
     "Ref": "refs/pull/1/head",
     "Source": "feature",
     "Target": "master",
+    "Base": {
+        "Ref": "master",
+        "Sha": "39af58f1eff02aa308e16913e887c8d50362b474",
+        "Repo": {
+            "ID": "6589",
+            "Namespace": "jcitizen",
+            "Name": "my-repo",
+            "FullName": "jcitizen/my-repo",
+            "Perm": {},
+            "Branch": "master",
+            "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
+            "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
+            "Link": "https://try.gitea.io/jcitizen/my-repo",
+            "Created": "2018-07-06T00:08:02Z",
+            "Updated": "2018-07-06T00:37:22Z"
+        }
+    },
+    "Head": {
+        "Ref": "feature",
+        "Sha": "4f5e7d8f15cf79387cfd8a0d30c58855ab61e138",
+        "Repo": {
+            "ID": "6589",
+            "Namespace": "jcitizen",
+            "Name": "my-repo",
+            "FullName": "jcitizen/my-repo",
+            "Perm": {},
+            "Branch": "master",
+            "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
+            "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
+            "Link": "https://try.gitea.io/jcitizen/my-repo",
+            "Created": "2018-07-06T00:08:02Z",
+            "Updated": "2018-07-06T00:37:22Z"
+        }
+    },
     "Fork": "jcitizen/my-repo",
     "Link": "https://try.gitea.io/jcitizen/my-repo/pulls/1",
     "Closed": false,
     "Merged": false,
+    "Mergeable": true,
     "Author": {
+        "ID": 6641,
         "Login": "jcitizen",
         "Name": "",
         "Email": "jcitizen@example.com",

--- a/scm/driver/gitea/testdata/pr_create.json
+++ b/scm/driver/gitea/testdata/pr_create.json
@@ -1,0 +1,11 @@
+{
+  "title": "Add License File",
+  "body": "Using a BSD License",
+  "base": "master",
+  "head": "feature",
+  "assignee":"",
+  "assignees": null,
+  "labels": null,
+  "milestone":0,
+  "due_date": null
+}

--- a/scm/driver/gitea/testdata/prs.json.golden
+++ b/scm/driver/gitea/testdata/prs.json.golden
@@ -7,11 +7,47 @@
         "Ref": "refs/pull/1/head",
         "Source": "feature",
         "Target": "master",
+        "Base": {
+            "Ref": "master",
+            "Sha": "39af58f1eff02aa308e16913e887c8d50362b474",
+            "Repo": {
+                "ID": "6589",
+                "Namespace": "jcitizen",
+                "Name": "my-repo",
+                "FullName": "jcitizen/my-repo",
+                "Perm": {},
+                "Branch": "master",
+                "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
+                "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
+                "Link": "https://try.gitea.io/jcitizen/my-repo",
+                "Created": "2018-07-06T00:08:02Z",
+                "Updated": "2018-07-06T00:37:22Z"
+            }
+        },
+        "Head": {
+            "Ref": "feature",
+            "Sha": "4f5e7d8f15cf79387cfd8a0d30c58855ab61e138",
+            "Repo": {
+                "ID": "6589",
+                "Namespace": "jcitizen",
+                "Name": "my-repo",
+                "FullName": "jcitizen/my-repo",
+                "Perm": {},
+                "Branch": "master",
+                "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
+                "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
+                "Link": "https://try.gitea.io/jcitizen/my-repo",
+                "Created": "2018-07-06T00:08:02Z",
+                "Updated": "2018-07-06T00:37:22Z"
+            }
+        },
         "Fork": "jcitizen/my-repo",
         "Link": "https://try.gitea.io/jcitizen/my-repo/pulls/1",
         "Closed": false,
         "Merged": false,
+        "Mergeable": true,
         "Author": {
+            "ID": 6641,
             "Login": "jcitizen",
             "Name": "",
             "Email": "jcitizen@example.com",

--- a/scm/driver/gitea/testdata/reopen_issue.json
+++ b/scm/driver/gitea/testdata/reopen_issue.json
@@ -1,0 +1,9 @@
+{
+  "title":"",
+  "body":null,
+  "assignee":null,
+  "assignees":null,
+  "milestone":null,
+  "state":"open",
+  "due_date":null
+}

--- a/scm/driver/gitea/testdata/reopen_pr.json
+++ b/scm/driver/gitea/testdata/reopen_pr.json
@@ -1,0 +1,11 @@
+{
+  "title":"",
+  "body":"",
+  "base": "",
+  "assignee":"",
+  "assignees": null,
+  "labels": null,
+  "milestone":0,
+  "state":"open",
+  "due_date": null
+}

--- a/scm/driver/gitea/testdata/repo.json.golden
+++ b/scm/driver/gitea/testdata/repo.json.golden
@@ -12,7 +12,7 @@
     "Private": true,
     "Clone": "https://try.gitea.io/go-gitea/gitea.git",
     "CloneSSH": "git@try.gitea.io:go-gitea/gitea.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "https://try.gitea.io/go-gitea/gitea",
+    "Created": "2017-10-22T18:25:33Z",
+    "Updated": "2017-11-16T22:07:01Z"
 }

--- a/scm/driver/gitea/testdata/repos.json.golden
+++ b/scm/driver/gitea/testdata/repos.json.golden
@@ -13,8 +13,8 @@
         "Private": true,
         "Clone": "https://try.gitea.io/go-gitea/gitea.git",
         "CloneSSH": "git@try.gitea.io:go-gitea/gitea.git",
-        "Link": "",
-        "Created": "0001-01-01T00:00:00Z",
-        "Updated": "0001-01-01T00:00:00Z"
+        "Link": "https://try.gitea.io/go-gitea/gitea",
+        "Created": "2017-10-22T18:25:33Z",
+        "Updated": "2017-11-16T22:07:01Z"
     }
 ]

--- a/scm/driver/gitea/testdata/unassign_issue.json
+++ b/scm/driver/gitea/testdata/unassign_issue.json
@@ -1,0 +1,9 @@
+{
+  "title":"Bug found",
+  "body":null,
+  "assignee":null,
+  "assignees":[],
+  "milestone":null,
+  "state":null,
+  "due_date":null
+}

--- a/scm/driver/gitea/testdata/user.json.golden
+++ b/scm/driver/gitea/testdata/user.json.golden
@@ -1,4 +1,5 @@
 {
+    "ID": 1,
     "Login": "jcitizen",
     "Name": "Jane Citizen",
     "Email": "jane@example.com",

--- a/scm/driver/gitea/testdata/webhooks/branch_create.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/branch_create.json.golden
@@ -8,17 +8,17 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:33:46Z"
   },
   "Action": "created",
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/driver/gitea/testdata/webhooks/branch_delete.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/branch_delete.json.golden
@@ -8,17 +8,17 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:37:02Z"
   },
   "Action": "deleted",
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/driver/gitea/testdata/webhooks/issue_comment_created.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/issue_comment_created.json.golden
@@ -5,14 +5,13 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:39:10Z"
   },
   "Issue": {
     "Number": 1,
@@ -23,6 +22,7 @@
     "Closed": false,
     "Locked": false,
     "Author": {
+      "ID": 1,
       "Login": "unknwon",
       "Name": "",
       "Email": "noreply@gogs.io",
@@ -35,6 +35,7 @@
     "ID": 43,
     "Body": "Got it",
     "Author": {
+      "ID": 1,
       "Login": "unknwon",
       "Name": "",
       "Email": "noreply@gogs.io",
@@ -44,6 +45,7 @@
     "Updated": "2017-12-08T17:39:10-08:00"
   },
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/driver/gitea/testdata/webhooks/issues_opened.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/issues_opened.json.golden
@@ -5,14 +5,13 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:39:10Z"
   },
   "Issue": {
     "Number": 1,
@@ -23,6 +22,7 @@
     "Closed": false,
     "Locked": false,
     "Author": {
+      "ID": 1,
       "Login": "unknwon",
       "Name": "",
       "Email": "noreply@gogs.io",
@@ -32,6 +32,7 @@
     "Updated": "2017-12-08T17:30:43-08:00"
   },
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/driver/gitea/testdata/webhooks/pull_request_closed.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_closed.json.golden
@@ -14,9 +14,9 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
+    "Created": "2018-07-06T00:08:02Z",
+    "Updated": "2018-07-06T01:06:56Z"
   },
   "PullRequest": {
     "Number": 1,
@@ -40,6 +40,7 @@
     "Updated": "0001-01-01T00:00:00Z"
   },
   "Sender": {
+    "ID": 6641,
     "Login": "jcitizen",
     "Name": "",
     "Email": "jane@example.com",

--- a/scm/driver/gitea/testdata/webhooks/pull_request_comment_created.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_comment_created.json.golden
@@ -5,14 +5,13 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T07:23:37Z"
   },
   "PullRequest": {
     "Number": 2,
@@ -26,6 +25,7 @@
     "Closed": false,
     "Merged": false,
     "Author": {
+      "ID": 1,
       "Login": "unknwon",
       "Name": "",
       "Email": "noreply@gogs.io",
@@ -39,6 +39,7 @@
     "Body": "run gofmt",
     "Author": {
       "Login": "unknwon",
+      "ID": 1,
       "Name": "",
       "Email": "noreply@gogs.io",
       "Avatar": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
@@ -47,6 +48,7 @@
     "Updated": "0001-01-01T00:00:00Z"
   },
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/driver/gitea/testdata/webhooks/pull_request_edited.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_edited.json.golden
@@ -14,9 +14,9 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
+    "Created": "2018-07-06T00:08:02Z",
+    "Updated": "2018-07-06T01:06:56Z"
   },
   "PullRequest": {
     "Number": 1,
@@ -40,6 +40,7 @@
     "Updated": "0001-01-01T00:00:00Z"
   },
   "Sender": {
+    "ID": 6641,
     "Login": "jcitizen",
     "Name": "",
     "Email": "jane@example.com",

--- a/scm/driver/gitea/testdata/webhooks/pull_request_merged.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_merged.json.golden
@@ -14,9 +14,9 @@
         "Private": false,
         "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
         "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-        "Link": "",
-        "Created": "0001-01-01T00:00:00Z",
-        "Updated": "0001-01-01T00:00:00Z"
+        "Link": "https://try.gitea.io/jcitizen/my-repo",
+        "Created": "2018-07-06T00:08:02Z",
+        "Updated": "2018-07-06T01:06:56Z"
     },
     "PullRequest": {
         "Number": 1,
@@ -40,6 +40,7 @@
         "Updated": "0001-01-01T00:00:00Z"
     },
     "Sender": {
+        "ID": 6641,
         "Login": "jcitizen",
         "Name": "",
         "Email": "jane@example.com",

--- a/scm/driver/gitea/testdata/webhooks/pull_request_opened.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_opened.json.golden
@@ -14,9 +14,9 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
+    "Created": "2018-07-06T00:08:02Z",
+    "Updated": "2018-07-06T01:06:56Z"
   },
   "PullRequest": {
     "Number": 1,
@@ -40,6 +40,7 @@
     "Updated": "0001-01-01T00:00:00Z"
   },
   "Sender": {
+    "ID": 6641,
     "Login": "jcitizen",
     "Name": "",
     "Email": "jane@example.com",

--- a/scm/driver/gitea/testdata/webhooks/pull_request_reopened.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_reopened.json.golden
@@ -14,9 +14,9 @@
         "Private": false,
         "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
         "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-        "Link": "",
-        "Created": "0001-01-01T00:00:00Z",
-        "Updated": "0001-01-01T00:00:00Z"
+        "Link": "https://try.gitea.io/jcitizen/my-repo",
+        "Created": "2018-07-06T00:08:02Z",
+        "Updated": "2018-07-06T01:06:56Z"
     },
     "PullRequest": {
         "Number": 1,
@@ -40,6 +40,7 @@
         "Updated": "0001-01-01T00:00:00Z"
     },
     "Sender": {
+        "ID": 6641,
         "Login": "jcitizen",
         "Name": "",
         "Email": "jane@example.com",

--- a/scm/driver/gitea/testdata/webhooks/pull_request_synchronized.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/pull_request_synchronized.json.golden
@@ -14,9 +14,9 @@
     "Private": false,
     "Clone": "https://try.gitea.io/jcitizen/my-repo.git",
     "CloneSSH": "git@try.gitea.io:jcitizen/my-repo.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "https://try.gitea.io/jcitizen/my-repo",
+    "Created": "2018-07-06T00:08:02Z",
+    "Updated": "2018-07-06T01:06:56Z"
   },
   "PullRequest": {
     "Number": 1,
@@ -40,6 +40,7 @@
     "Updated": "0001-01-01T00:00:00Z"
   },
   "Sender": {
+    "ID": 6641,
     "Login": "jcitizen",
     "Name": "",
     "Email": "jane@example.com",

--- a/scm/driver/gitea/testdata/webhooks/push.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/push.json.golden
@@ -5,14 +5,13 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:33:08Z"
   },
   "Commit": {
     "Sha": "4522cbcefc20728a5b72b3a86af35e608622c514",
@@ -34,6 +33,7 @@
     "Link": "http://try.gitea.io/gogits/hello-world/compare/9836a96a253cce25d17988fcf41b8c4205cf779f...4522cbcefc20728a5b72b3a86af35e608622c514"
   },
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/driver/gitea/testdata/webhooks/tag_create.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/tag_create.json.golden
@@ -8,17 +8,17 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:38:03Z"
   },
   "Action": "created",
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/driver/gitea/testdata/webhooks/tag_delete.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/tag_delete.json.golden
@@ -8,17 +8,17 @@
     "Namespace": "gogits",
     "Name": "hello-world",
     "FullName": "gogits/hello-world",
-    "Perm": {},
     "Branch": "master",
     "Private": true,
     "Clone": "http://try.gitea.io/gogits/hello-world.git",
     "CloneSSH": "git@localhost:gogits/hello-world.git",
-    "Link": "",
-    "Created": "0001-01-01T00:00:00Z",
-    "Updated": "0001-01-01T00:00:00Z"
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:38:47Z"
   },
   "Action": "deleted",
   "Sender": {
+    "ID": 1,
     "Login": "unknwon",
     "Name": "",
     "Email": "noreply@gogs.io",

--- a/scm/org.go
+++ b/scm/org.go
@@ -39,7 +39,8 @@ type (
 
 	// TeamMember is a member of an organizational team
 	TeamMember struct {
-		Login string `json:"login"`
+		Login   string `json:"login"`
+		IsAdmin bool   `json:"isAdmin,omitempty"`
 	}
 
 	// OrganizationService provides access to organization resources.


### PR DESCRIPTION
This saves a _lot_ of effort in implementing functions. I'll probably follow up by populating the remainder of relevant functions, but this adds the ones that Lighthouse tests would need at a minimum and changes everything currently in place to be a shim over https://gitea.com/gitea/go-sdk/ (except for `ListChanges` for annoying reasons).