### PR TITLE
fix: make testing content with refs easier for fake

### DIFF
--- a/scm/driver/fake/content.go
+++ b/scm/driver/fake/content.go
@@ -112,5 +112,30 @@ func (c contentService) path(repo string, path string, ref string) (string, erro
 	if c.data.ContentDir == "" {
 		return "", errors.Errorf("no data.ContentDir configured")
 	}
-	return filepath.Join(c.data.ContentDir, repo, path), nil
+	if ref == "" {
+		ref = "master"
+	}
+	repoDir := filepath.Join(c.data.ContentDir, repo)
+
+	// lets see if there's a 'refs' folder for testing out different files in different ref/shas
+	refDir := filepath.Join(repoDir, "refs", ref)
+	exists, err := DirExists(refDir)
+	if err != nil {
+		return repoDir, errors.Wrapf(err, "failed to check if refs dir %s exists", refDir)
+	}
+	if exists {
+		repoDir = refDir
+	}
+	return filepath.Join(repoDir, path), nil
+}
+
+/// DirExists checks if path exists and is a directory
+func DirExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		return info.IsDir(), nil
+	} else if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }

--- a/scm/driver/fake/content_test.go
+++ b/scm/driver/fake/content_test.go
@@ -2,6 +2,8 @@ package fake
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,4 +42,37 @@ func TestContent(t *testing.T) {
 	t.Logf("loaded repo %s path %s got %s\n", repo, path, text)
 
 	assert.Contains(t, text, "root dir of a repo", "for repo %s path %s", repo, path)
+}
+
+func TestContentWithRefs(t *testing.T) {
+	client, fakeData := NewDefault()
+	fakeData.ContentDir = filepath.Join("test_data", "test_refs")
+
+	ctx := context.Background()
+	repo := "myorg/myrepo"
+	path := "something.txt"
+
+	testCases := []struct {
+		ref      string
+		expected string
+	}{
+		{
+			ref:      "master",
+			expected: "main text",
+		},
+		{
+			ref:      "mybranch",
+			expected: "my changes on a branch",
+		},
+	}
+	for _, tc := range testCases {
+		ref := tc.ref
+		c, _, err := client.Contents.Find(ctx, repo, path, ref)
+		require.NoError(t, err, "could not find file in repo %s path %s", repo, path)
+
+		text := strings.TrimSpace(string(c.Data))
+
+		assert.Equal(t, tc.expected, text, "for repo path %s ref %", repo, ref, path)
+		t.Logf("loaded repo %s path %s ref %s got %s\n", repo, ref, path, text)
+	}
 }

--- a/scm/driver/fake/test_data/test_refs/myorg/myrepo/README.md
+++ b/scm/driver/fake/test_data/test_refs/myorg/myrepo/README.md
@@ -1,0 +1,1 @@
+To simulate a git service with different files in different refs create a folder for each ref

--- a/scm/driver/fake/test_data/test_refs/myorg/myrepo/refs/master/something.txt
+++ b/scm/driver/fake/test_data/test_refs/myorg/myrepo/refs/master/something.txt
@@ -1,0 +1,1 @@
+main text

--- a/scm/driver/fake/test_data/test_refs/myorg/myrepo/refs/mybranch/something.txt
+++ b/scm/driver/fake/test_data/test_refs/myorg/myrepo/refs/mybranch/something.txt
@@ -1,0 +1,1 @@
+my changes on a branch


### PR DESCRIPTION
so you can more easily create the fake git provider with different content in different refs using the convention of `test_data/$owner/$repo/refs/$ref/$fileName`

Signed-off-by: James Strachan <james.strachan@gmail.com>