### PR TITLE
fix: Paginate for lookup-by-listing GitLab functions

### DIFF
--- a/scm/driver/gitlab/gitlab_test.go
+++ b/scm/driver/gitlab/gitlab_test.go
@@ -33,6 +33,13 @@ var mockPageHeaders = map[string]string{
 		`<https://gitlab.com/resource?page=5>; rel="last"`,
 }
 
+var mockPageHeadersNoPagination = map[string]string{
+	"Link": `<https://gitlab.com/resource?page=1>; rel="next",` +
+		`<https://gitlab.com/resource?page=1>; rel="prev",` +
+		`<https://gitlab.com/resource?page=1>; rel="first",` +
+		`<https://gitlab.com/resource?page=1>; rel="last"`,
+}
+
 const mimeJSON = "application/json"
 
 func TestClient(t *testing.T) {

--- a/scm/driver/gitlab/repo_test.go
+++ b/scm/driver/gitlab/repo_test.go
@@ -317,10 +317,11 @@ func TestCombinedStatus(t *testing.T) {
 
 	gock.New("https://gitlab.com").
 		Get("/api/v4/projects/thedude/gitlab-ce/repository/commits/18f3e63d05582537db6d183d9d557be09e1f90c8/statuses").
+		MatchParam("page", "1").
 		Reply(200).
 		Type("application/json").
 		SetHeaders(mockHeaders).
-		SetHeaders(mockPageHeaders).
+		SetHeaders(mockPageHeadersNoPagination).
 		File("testdata/statuses.json")
 
 	client := NewDefault()
@@ -341,7 +342,6 @@ func TestCombinedStatus(t *testing.T) {
 
 	t.Run("Request", testRequest(res))
 	t.Run("Rate", testRate(res))
-	t.Run("Page", testPage(res))
 }
 
 func TestStatusCreate(t *testing.T) {


### PR DESCRIPTION
A few GitLab functions need to list team members, statuses, and the like before finding the right return value, where GitHub/Gitea just requires a direct call. We need to automatically paginate for those functions to make sure we traverse all possibilities.

fixes #174

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>