### PR TITLE
chore: add DeleteRef to gitea

### DIFF
--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -5,10 +5,11 @@
 package gitea
 
 import (
-	"code.gitea.io/sdk/gitea"
 	"context"
 	"fmt"
 	"time"
+
+	"code.gitea.io/sdk/gitea"
 
 	"github.com/jenkins-x/go-scm/scm"
 )
@@ -37,7 +38,9 @@ func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm
 }
 
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	namespace, name := scm.Split(repo)
+	_, err := s.client.GiteaClient.DeleteRepoBranch(namespace, name, ref)
+	return dummyResponse(), err
 }
 
 func (s *gitService) FindBranch(ctx context.Context, repo, branchName string) (*scm.Reference, *scm.Response, error) {


### PR DESCRIPTION
This PR adds DeleteRef support to gitea.
Not sure how to deal with `refs/` `heads/` etc...
For example, in Lighthouse, the branchcleaner plugin formats the branch name `heads/name` (see [here](https://github.com/jenkins-x/lighthouse/blob/5fd1d1f5e64ec136ed18591181f1e863e0667cca/pkg/plugins/branchcleaner/branchcleaner.go#L63)).

/cc @abayer 