### PR TITLE
fix: `json: cannot unmarshall array into Go value of type gitlab.gl_name`

### DIFF
--- a/scm/driver/gitlab/gitlab.go
+++ b/scm/driver/gitlab/gitlab.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -100,7 +101,8 @@ type gl_namespace struct {
 	Kind                        string `json:"kind"`
 	FullPath                    string `json:"full_path"`
 	ParentID                    int    `json:"parent_id"`
-	MembersCountWithDescendants int    `json:"members_count_with_descendants"`
+	AvatarURL                   string  `json:"avatar_url"`
+	WebURL                      string  `json:"web_url"`
 }
 
 // findNamespaceByName will look up the namespace for the given name
@@ -115,9 +117,8 @@ func (c *wrapper) findNamespaceByName(ctx context.Context, name string) (*gl_nam
 	return out, err
 }
 
-// do wraps the Client.Do function by creating the Request and
-// unmarshalling the response.
-func (c *wrapper) do(ctx context.Context, method, path string, in, out interface{}) (*scm.Response, error) {
+// `do_gl_namespace` is very same with `do()`, but it needs one further step to convert array to json for correct marshall
+func (c *wrapper) do_gl_namespace(ctx context.Context, method, path string, in, out interface{}) (*scm.Response, error) {
 	req := &scm.Request{
 		Method: method,
 		Path:   path,
@@ -169,9 +170,82 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 		return res, nil
 	}
 
+	// remove the bracket to convert array to json for correct marshall into gl_namespace
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, res.Body)
+	str_buf := buf.String()
+	new_str := buf.String()[1:len(str_buf)-1]
+
 	// if a json response is expected, parse and return
 	// the json response.
-	return res, json.NewDecoder(res.Body).Decode(out)
+	return res, json.Unmarshal([]byte(new_str),&out)
+}
+
+// do wraps the Client.Do function by creating the Request and
+// unmarshalling the response.
+func (c *wrapper) do(ctx context.Context, method, path string, in, out interface{}) (*scm.Response, error) {
+	req := &scm.Request{
+		Method: method,
+		Path:   path,
+	}
+	// if we are posting or putting data, we need to
+	// write it to the body of the request.
+	if in != nil {
+		buf := new(bytes.Buffer)
+		json.NewEncoder(buf).Encode(in)
+		if req.Header == nil {
+			req.Header = map[string][]string{}
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Body = buf
+	}
+	// execute the http request
+	res, err := c.Client.Do(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	// parse the gitlab request id.
+	res.ID = res.Header.Get("X-Request-Id")
+
+	// parse the gitlab rate limit details.
+	res.Rate.Limit, _ = strconv.Atoi(
+		res.Header.Get("RateLimit-Limit"),
+	)
+	res.Rate.Remaining, _ = strconv.Atoi(
+		res.Header.Get("RateLimit-Remaining"),
+	)
+	res.Rate.Reset, _ = strconv.ParseInt(
+		res.Header.Get("RateLimit-Reset"), 10, 64,
+	)
+
+	// snapshot the request rate limit
+	c.Client.SetRate(res.Rate)
+
+	// if an error is encountered, unmarshal and return the
+	// error response.
+	if res.Status > 300 {
+		buf := new(strings.Builder)
+		_, err = io.Copy(buf, res.Body)
+		str_buf := buf.String()
+		err_i := new(Error)
+		json.Unmarshal([]byte(str_buf),&err_i)
+
+		return res, err_i
+	}
+
+	if out == nil {
+		return res, nil
+	}
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, res.Body)
+	str_buf := buf.String()
+
+	// if a json response is expected, parse and return
+	// the json response.
+	return res, json.Unmarshal([]byte(str_buf),&out)
 }
 
 // Error represents a GitLab error.


### PR DESCRIPTION
Jenkins X v3 is using go-scm to support different git providers. The error `error: failed to create git repository username/projectname: json: cannot unmarshal array into Go value of type gitlab.gl_namespace` occurred for the reason that it's trying to decode array into json. This pull request is to solve this issue by adding a specific function to ensure it's unmarshall json to `out`. 

Also, the previous `decode` in do() did not work well and always returned null/empty struct to `out`, and this pull request fix this issue.