### PR TITLE
fix: Populate base repo in GitLab PRs

### DIFF
--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -355,23 +355,29 @@ func (s *repositoryService) CreateHook(ctx context.Context, repo string, input *
 	if input.SkipVerify {
 		params.Set("enable_ssl_verification", "true")
 	}
+	hasStarEvents := false
+	for _, event := range input.NativeEvents {
+		if event == "*" {
+			hasStarEvents = true
+		}
+	}
 	if input.Events.Branch {
 		// no-op
 	}
-	if input.Events.Issue {
+	if input.Events.Issue || hasStarEvents {
 		params.Set("issues_events", "true")
 	}
 	if input.Events.IssueComment ||
-		input.Events.PullRequestComment {
+		input.Events.PullRequestComment || hasStarEvents {
 		params.Set("note_events", "true")
 	}
-	if input.Events.PullRequest {
+	if input.Events.PullRequest || hasStarEvents {
 		params.Set("merge_requests_events", "true")
 	}
-	if input.Events.Push || input.Events.Branch {
+	if input.Events.Push || input.Events.Branch || hasStarEvents {
 		params.Set("push_events", "true")
 	}
-	if input.Events.Tag {
+	if input.Events.Tag || hasStarEvents {
 		params.Set("tag_push_events", "true")
 	}
 

--- a/scm/driver/gitlab/testdata/merge.json.golden
+++ b/scm/driver/gitlab/testdata/merge.json.golden
@@ -38,7 +38,10 @@
     "Base": {
         "Ref": "master",
         "Repo": {
-            "ID": "32732"
+            "ID": "32732",
+            "Name": "diaspora",
+            "Namespace": "diaspora",
+            "FullName": "diaspora/diaspora"
         }
     }
 }

--- a/scm/driver/gitlab/testdata/merges.json.golden
+++ b/scm/driver/gitlab/testdata/merges.json.golden
@@ -33,7 +33,10 @@
         "Base": {
             "Ref": "master",
             "Repo": {
-                "ID": "32732"
+                "ID": "32732",
+                "Name": "diaspora",
+                "Namespace": "diaspora",
+                "FullName": "diaspora/diaspora"
             }
         }
     }

--- a/scm/driver/gitlab/testdata/pr_create.json.golden
+++ b/scm/driver/gitlab/testdata/pr_create.json.golden
@@ -12,9 +12,9 @@
     "Sha": "c380d3acebd181f13629a25d2e2acca46ffe1e00",
     "Repo": {
       "ID": "3",
-      "Namespace": "",
-      "Name": "",
-      "FullName": "",
+      "Name": "diaspora",
+      "Namespace": "diaspora",
+      "FullName": "diaspora/diaspora",
       "Perm": null,
       "Branch": "",
       "Private": false,


### PR DESCRIPTION
We depend on the `Name`, `Namespace`, and/or `FullName` fields being set in the `Base.Repo` for a PR in Lighthouse tests, so let's set them. We might want to change this up to query for the head/base repos in full, but this approach, while minimal, doesn't require additional API calls.