### PR TITLE
fix: improve fake support for invitations

### DIFF
--- a/scm/driver/fake/content_test.go
+++ b/scm/driver/fake/content_test.go
@@ -1,4 +1,4 @@
-package fake
+package fake_test
 
 import (
 	"context"
@@ -6,12 +6,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestContent(t *testing.T) {
-	client, _ := NewDefault()
+	client, _ := fake.NewDefault()
 
 	ctx := context.Background()
 	sha := "master"
@@ -45,7 +46,7 @@ func TestContent(t *testing.T) {
 }
 
 func TestContentWithRefs(t *testing.T) {
-	client, fakeData := NewDefault()
+	client, fakeData := fake.NewDefault()
 	fakeData.ContentDir = filepath.Join("test_data", "test_refs")
 
 	ctx := context.Background()

--- a/scm/driver/fake/data.go
+++ b/scm/driver/fake/data.go
@@ -67,6 +67,9 @@ type Data struct {
 
 	UserPermissions map[string]map[string]string
 
+	// Invitations the current pending invitations
+	Invitations []*scm.Invitation
+
 	// ContentDir the directory used to implement the Content service to access files and directories
 	ContentDir string
 }

--- a/scm/driver/fake/repo.go
+++ b/scm/driver/fake/repo.go
@@ -72,6 +72,31 @@ func (s *repositoryService) AddCollaborator(ctx context.Context, repo, user, per
 	m[user] = permission
 
 	s.data.UserPermissions[repo] = m
+
+	// lets add an invitation if the user isn't already in the repo...
+	if !alreadyExists {
+		id := int64(len(s.data.Invitations) + 1)
+		names := strings.SplitN(repo, "/", 2)
+		owner := ""
+		repoName := ""
+		if len(names) == 2 {
+			owner = names[0]
+			repoName = names[1]
+		}
+		s.data.Invitations = append(s.data.Invitations, &scm.Invitation{
+			ID: id,
+			Repo: &scm.Repository{
+				Namespace: owner,
+				Name:      repoName,
+				FullName:  repo,
+			},
+			Invitee:     &scm.User{},
+			Inviter:     &scm.User{},
+			Permissions: permission,
+			Created:     time.Now(),
+		})
+	}
+
 	return true, alreadyExists, nil, nil
 }
 

--- a/scm/driver/fake/user.go
+++ b/scm/driver/fake/user.go
@@ -37,9 +37,20 @@ func (u *userService) FindLogin(ctx context.Context, login string) (*scm.User, *
 }
 
 func (s *userService) ListInvitations(context.Context) ([]*scm.Invitation, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+	return s.data.Invitations, nil, nil
 }
 
-func (s *userService) AcceptInvitation(context.Context, int64) (*scm.Response, error) {
+func (s *userService) AcceptInvitation(_ context.Context, id int64) (*scm.Response, error) {
+	invitations := s.data.Invitations
+	for i, invite := range invitations {
+		if invite.ID == id {
+			remaining := invitations[0:i]
+			if i+1 < len(invitations) {
+				remaining = append(remaining, invitations[i+1:]...)
+			}
+			s.data.Invitations = remaining
+			return nil, nil
+		}
+	}
 	return nil, scm.ErrNotSupported
 }

--- a/scm/driver/fake/user_test.go
+++ b/scm/driver/fake/user_test.go
@@ -1,0 +1,48 @@
+package fake_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jenkins-x/go-scm/scm"
+	"github.com/jenkins-x/go-scm/scm/driver/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInviteLogic(t *testing.T) {
+	client, data := fake.NewDefault()
+
+	ctx := context.Background()
+	owner := "myorg"
+	repo := "myrepo"
+	permission := "admin"
+	user := "jstrachan"
+	fullName := scm.Join(owner, repo)
+
+	invitations, _, err := client.Users.ListInvitations(ctx)
+	require.NoError(t, err, "could not list invitations in repo %s", fullName)
+	require.Empty(t, invitations, "should not have any invitations")
+
+	addedFlag, alreadyExisted, _, err := client.Repositories.AddCollaborator(ctx, fullName, user, permission)
+	assert.True(t, addedFlag, "should have added a collaborator")
+	assert.False(t, alreadyExisted, "the collaborator %s should not already exist", user)
+
+	require.NotEmpty(t, data.UserPermissions[fullName], "should have a user permission for repo %s", fullName)
+	assert.Equal(t, permission, data.UserPermissions[fullName][user], "should have a permission for repo %s and user %s", fullName, user)
+
+	invitations, _, err = client.Users.ListInvitations(ctx)
+	require.NoError(t, err, "could not list invitations in repo %s", fullName)
+	require.Len(t, invitations, 1, "should have one invitation")
+
+	invitation := invitations[0]
+	t.Logf("we now have an invite %v for repo %s\n", invitation.ID, invitation.Repo.FullName)
+
+	_, err = client.Users.AcceptInvitation(ctx, invitation.ID)
+	require.NoError(t, err, "should not have failed to accept invite for %v", invitation.ID)
+
+	// should have no pending invitations now
+	invitations, _, err = client.Users.ListInvitations(ctx)
+	require.NoError(t, err, "could not list invitations in repo %s", fullName)
+	require.Empty(t, invitations, "should not have any invitations")
+}


### PR DESCRIPTION
lets add a unit test to list invitations, add a collaborator and accept an invite and assert that the fake provider should behave as we'd expect

Signed-off-by: James Strachan <james.strachan@gmail.com>