### PR TITLE
fix: Fetch repo info when converting GitLab PRs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.0
 	github.com/h2non/gock v1.0.9
+	github.com/mitchellh/copystructure v1.0.0
 	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,10 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
+github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
+github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/IfikLNY=
+github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=

--- a/scm/driver/gitlab/content.go
+++ b/scm/driver/gitlab/content.go
@@ -110,13 +110,12 @@ type updateContentBody struct {
 }
 
 type entry struct {
-	Id string `json:"id"`
+	Id   string `json:"id"`
 	Name string `json:"name"`
 	Type string `json:"type"`
 	Path string `json:"path"`
 	Mode string `json:"mode"`
 }
-
 
 func convertEntryList(out []*entry) []*scm.FileEntry {
 	answer := make([]*scm.FileEntry, 0, len(out))

--- a/scm/driver/gitlab/pr_test.go
+++ b/scm/driver/gitlab/pr_test.go
@@ -20,6 +20,13 @@ func TestPullFind(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
 		Get("/api/v4/projects/diaspora/diaspora/merge_requests/1347").
 		Reply(200).
 		Type("application/json").
@@ -42,7 +49,7 @@ func TestPullFind(t *testing.T) {
 		t.Fatalf("json.Unmarshal: %v", err)
 	}
 
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
 	}
@@ -53,6 +60,13 @@ func TestPullFind(t *testing.T) {
 
 func TestPullList(t *testing.T) {
 	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
 
 	updatedAfter, _ := time.Parse(scm.SearchTimeFormat, "2015-12-18T17:30:22.522Z")
 	gock.New("https://gitlab.com").
@@ -350,6 +364,20 @@ func TestPullCreate(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
+
+	gock.New("https://gitlab.com").
 		Post("/api/v4/projects/diaspora/diaspora/merge_requests").
 		Reply(201).
 		Type("application/json").
@@ -373,7 +401,7 @@ func TestPullCreate(t *testing.T) {
 	raw, _ := ioutil.ReadFile("testdata/pr_create.json.golden")
 	json.Unmarshal(raw, want)
 
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
 	}
@@ -384,6 +412,20 @@ func TestPullCreate(t *testing.T) {
 
 func TestPullUpdate(t *testing.T) {
 	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
 
 	gock.New("https://gitlab.com").
 		Put("/api/v4/projects/diaspora/diaspora/merge_requests/1").
@@ -458,6 +500,20 @@ func TestPullSetMilestone(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
+
+	gock.New("https://gitlab.com").
 		Put("/api/v4/projects/diaspora/diaspora/merge_requests/1").
 		File("testdata/issue_or_pr_set_milestone.json").
 		Reply(201).
@@ -474,6 +530,20 @@ func TestPullSetMilestone(t *testing.T) {
 
 func TestPullClearMilestone(t *testing.T) {
 	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
 
 	gock.New("https://gitlab.com").
 		Put("/api/v4/projects/diaspora/diaspora/merge_requests/1").

--- a/scm/driver/gitlab/testdata/merge.json.golden
+++ b/scm/driver/gitlab/testdata/merge.json.golden
@@ -32,16 +32,43 @@
         "Ref": "fix",
         "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
         "Repo": {
-            "ID": "32732"
+            "ID": "32732",
+            "Namespace": "diaspora",
+            "Name": "diaspora",
+            "FullName": "diaspora/diaspora",
+            "Perm": {
+                "Pull": true,
+                "Push": false,
+                "Admin": false
+            },
+            "Branch": "master",
+            "Private": false,
+            "Clone": "https://gitlab.com/diaspora/diaspora.git",
+            "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
+            "Link": "",
+            "Created": "0001-01-01T00:00:00Z",
+            "Updated": "0001-01-01T00:00:00Z"
         }
     },
     "Base": {
         "Ref": "master",
         "Repo": {
             "ID": "32732",
-            "Name": "diaspora",
             "Namespace": "diaspora",
-            "FullName": "diaspora/diaspora"
+            "Name": "diaspora",
+            "FullName": "diaspora/diaspora",
+            "Perm": {
+                "Pull": true,
+                "Push": false,
+                "Admin": false
+            },
+            "Branch": "master",
+            "Private": false,
+            "Clone": "https://gitlab.com/diaspora/diaspora.git",
+            "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
+            "Link": "",
+            "Created": "0001-01-01T00:00:00Z",
+            "Updated": "0001-01-01T00:00:00Z"
         }
     }
 }

--- a/scm/driver/gitlab/testdata/merges.json.golden
+++ b/scm/driver/gitlab/testdata/merges.json.golden
@@ -27,16 +27,43 @@
             "Ref": "fix",
             "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
             "Repo": {
-                "ID": "32732"
+                "ID": "32732",
+                "Namespace": "diaspora",
+                "Name": "diaspora",
+                "FullName": "diaspora/diaspora",
+                "Perm": {
+                    "Pull": true,
+                    "Push": false,
+                    "Admin": false
+                },
+                "Branch": "master",
+                "Private": false,
+                "Clone": "https://gitlab.com/diaspora/diaspora.git",
+                "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
+                "Link": "",
+                "Created": "0001-01-01T00:00:00Z",
+                "Updated": "0001-01-01T00:00:00Z"
             }
         },
         "Base": {
             "Ref": "master",
             "Repo": {
                 "ID": "32732",
-                "Name": "diaspora",
                 "Namespace": "diaspora",
-                "FullName": "diaspora/diaspora"
+                "Name": "diaspora",
+                "FullName": "diaspora/diaspora",
+                "Perm": {
+                    "Pull": true,
+                    "Push": false,
+                    "Admin": false
+                },
+                "Branch": "master",
+                "Private": false,
+                "Clone": "https://gitlab.com/diaspora/diaspora.git",
+                "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
+                "Link": "",
+                "Created": "0001-01-01T00:00:00Z",
+                "Updated": "0001-01-01T00:00:00Z"
             }
         }
     }

--- a/scm/driver/gitlab/testdata/other_repo.json
+++ b/scm/driver/gitlab/testdata/other_repo.json
@@ -1,5 +1,5 @@
 {
-    "id": 32732,
+    "id": 2,
     "description": "",
     "default_branch": "master",
     "tag_list": [],
@@ -16,13 +16,13 @@
     "created_at": "2015-03-03T18:37:05.387Z",
     "last_activity_at": "2015-03-03T18:37:20.795Z",
     "_links": {
-        "self": "http://gitlab.com/api/v4/projects/32732",
-        "issues": "http://gitlab.com/api/v4/projects/32732/issues",
-        "merge_requests": "http://gitlab.com/api/v4/projects/32732/merge_requests",
-        "repo_branches": "http://gitlab.com/api/v4/projects/32732/repository/branches",
-        "labels": "http://gitlab.com/api/v4/projects/32732/labels",
-        "events": "http://gitlab.com/api/v4/projects/32732/events",
-        "members": "http://gitlab.com/api/v4/projects/32732/members"
+        "self": "http://gitlab.com/api/v4/projects/2",
+        "issues": "http://gitlab.com/api/v4/projects/2/issues",
+        "merge_requests": "http://gitlab.com/api/v4/projects/2/merge_requests",
+        "repo_branches": "http://gitlab.com/api/v4/projects/2/repository/branches",
+        "labels": "http://gitlab.com/api/v4/projects/2/labels",
+        "events": "http://gitlab.com/api/v4/projects/2/events",
+        "members": "http://gitlab.com/api/v4/projects/2/members"
     },
     "archived": false,
     "visibility": "public",

--- a/scm/driver/gitlab/testdata/pr_create.json
+++ b/scm/driver/gitlab/testdata/pr_create.json
@@ -28,7 +28,7 @@
     "web_url" : "https://gitlab.example.com/admin"
   },
   "source_project_id": 2,
-  "target_project_id": 3,
+  "target_project_id": 32732,
   "labels": [
     "Community contribution",
     "Manage"

--- a/scm/driver/gitlab/testdata/pr_create.json.golden
+++ b/scm/driver/gitlab/testdata/pr_create.json.golden
@@ -11,15 +11,19 @@
     "Ref": "master",
     "Sha": "c380d3acebd181f13629a25d2e2acca46ffe1e00",
     "Repo": {
-      "ID": "3",
-      "Name": "diaspora",
+      "ID": "32732",
       "Namespace": "diaspora",
+      "Name": "diaspora",
       "FullName": "diaspora/diaspora",
-      "Perm": null,
-      "Branch": "",
+      "Perm": {
+        "Pull": true,
+        "Push": false,
+        "Admin": false
+      },
+      "Branch": "master",
       "Private": false,
-      "Clone": "",
-      "CloneSSH": "",
+      "Clone": "https://gitlab.com/diaspora/diaspora.git",
+      "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
       "Link": "",
       "Created": "0001-01-01T00:00:00Z",
       "Updated": "0001-01-01T00:00:00Z"
@@ -30,14 +34,18 @@
     "Sha": "8888888888888888888888888888888888888888",
     "Repo": {
       "ID": "2",
-      "Namespace": "",
-      "Name": "",
-      "FullName": "",
-      "Perm": null,
-      "Branch": "",
+      "Namespace": "diaspora",
+      "Name": "diaspora",
+      "FullName": "diaspora/diaspora",
+      "Perm": {
+        "Pull": true,
+        "Push": false,
+        "Admin": false
+      },
+      "Branch": "master",
       "Private": false,
-      "Clone": "",
-      "CloneSSH": "",
+      "Clone": "https://gitlab.com/diaspora/diaspora.git",
+      "CloneSSH": "git@gitlab.com:diaspora/diaspora.git",
       "Link": "",
       "Created": "0001-01-01T00:00:00Z",
       "Updated": "0001-01-01T00:00:00Z"

--- a/scm/driver/gitlab/testdata/repo.json.golden
+++ b/scm/driver/gitlab/testdata/repo.json.golden
@@ -1,5 +1,5 @@
 {
-    "ID": "178504",
+    "ID": "32732",
     "Namespace": "diaspora",
     "Name": "diaspora",
     "FullName": "diaspora/diaspora",

--- a/scm/driver/gitlab/testdata/repos.json
+++ b/scm/driver/gitlab/testdata/repos.json
@@ -1,6 +1,6 @@
 [
     {
-        "id": 178504,
+        "id": 32732,
         "description": "",
         "default_branch": "master",
         "tag_list": [],
@@ -17,13 +17,13 @@
         "created_at": "2015-03-03T18:37:05.387Z",
         "last_activity_at": "2015-03-03T18:37:20.795Z",
         "_links": {
-            "self": "http://gitlab.com/api/v4/projects/178504",
-            "issues": "http://gitlab.com/api/v4/projects/178504/issues",
-            "merge_requests": "http://gitlab.com/api/v4/projects/178504/merge_requests",
-            "repo_branches": "http://gitlab.com/api/v4/projects/178504/repository/branches",
-            "labels": "http://gitlab.com/api/v4/projects/178504/labels",
-            "events": "http://gitlab.com/api/v4/projects/178504/events",
-            "members": "http://gitlab.com/api/v4/projects/178504/members"
+            "self": "http://gitlab.com/api/v4/projects/32732",
+            "issues": "http://gitlab.com/api/v4/projects/32732/issues",
+            "merge_requests": "http://gitlab.com/api/v4/projects/32732/merge_requests",
+            "repo_branches": "http://gitlab.com/api/v4/projects/32732/repository/branches",
+            "labels": "http://gitlab.com/api/v4/projects/32732/labels",
+            "events": "http://gitlab.com/api/v4/projects/32732/events",
+            "members": "http://gitlab.com/api/v4/projects/32732/members"
         },
         "archived": false,
         "visibility": "public",

--- a/scm/driver/gitlab/testdata/repos.json.golden
+++ b/scm/driver/gitlab/testdata/repos.json.golden
@@ -1,6 +1,6 @@
 [
     {
-        "ID": "178504",
+        "ID": "32732",
         "Namespace": "diaspora",
         "Name": "diaspora",
         "FullName": "diaspora/diaspora",


### PR DESCRIPTION
GitLab just provides project IDs for source/target for merge requests, so we need to look up the repo information at some point. I've decided to move that logic into here rather than working around it in Lighthouse.

This could be optimized to do better caching - it already avoids looking up twice if the source and target repos are the same project ID, but we could do even more by adding a cache to the pull service. I feel like that's probably more work than strictly necessary so will defer for now.

Permanent fix for the issue seen on https://github.com/jenkins-x/lighthouse/pull/1108 (caused by #194, my attempt to deal with some of this issue) and worked around in https://github.com/jenkins-x/lighthouse/pull/1107/commits/35c0e09bced8ba0717ffe050ab142f174adc01c6

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>