### PR TITLE
Pass status code on http error

### DIFF
--- a/scm/driver/bitbucket/bitbucket.go
+++ b/scm/driver/bitbucket/bitbucket.go
@@ -9,7 +9,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -90,9 +92,9 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 	if res.Status == 401 {
 		return res, scm.ErrNotAuthorized
 	} else if res.Status > 300 {
-		err := new(Error)
-		json.NewDecoder(res.Body).Decode(err) // #nosec
-		return res, err
+		return res, errors.New(
+			http.StatusText(res.Status),
+		)
 	}
 
 	if out == nil {

--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -56,7 +56,7 @@ func TestRepositoryFind_NotFound(t *testing.T) {
 		t.Errorf("Expect not found message")
 	}
 
-	if got, want := err.Error(), "Repository dev/null not found"; got != want {
+	if got, want := err.Error(), "Not Found"; got != want {
 		t.Errorf("Want error message %q, got %q", want, got)
 	}
 }

--- a/scm/driver/github/github.go
+++ b/scm/driver/github/github.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -159,9 +160,9 @@ func (c *wrapper) doRequest(ctx context.Context, req *scm.Request, in, out inter
 		if res.Status == 404 {
 			return res, scm.ErrNotFound
 		}
-		err := new(Error)
-		json.NewDecoder(res.Body).Decode(err)
-		return res, err
+		return res, errors.New(
+			http.StatusText(res.Status),
+		)
 	}
 
 	if out == nil {

--- a/scm/driver/gitlab/gitlab.go
+++ b/scm/driver/gitlab/gitlab.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -163,9 +164,9 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 	// if an error is encountered, unmarshal and return the
 	// error response.
 	if res.Status > 300 {
-		err := new(Error)
-		json.NewDecoder(res.Body).Decode(err)
-		return res, err
+		return res, errors.New(
+			http.StatusText(res.Status),
+		)
 	}
 
 	if out == nil {

--- a/scm/driver/gitlab/repo_test.go
+++ b/scm/driver/gitlab/repo_test.go
@@ -176,7 +176,7 @@ func TestRepositoryNotFound(t *testing.T) {
 		t.Errorf("Expect Not Found error")
 		return
 	}
-	if got, want := err.Error(), "404 Project Not Found"; got != want {
+	if got, want := err.Error(), "Not Found"; got != want {
 		t.Errorf("Want error %q, got %q", want, got)
 	}
 }

--- a/scm/driver/gitlab/user_test.go
+++ b/scm/driver/gitlab/user_test.go
@@ -115,7 +115,7 @@ func TestUserLoginFind_NotAuthorized(t *testing.T) {
 		t.Errorf("Want 401 Unauthorized")
 		return
 	}
-	if got, want := err.Error(), "401 Unauthorized"; got != want {
+	if got, want := err.Error(), "Unauthorized"; got != want {
 		t.Errorf("Want %s, got %s", want, got)
 	}
 }


### PR DESCRIPTION
Current implementation fails to pass error messages back to users in the
case of some errors, notably 403 errors from gitlab. This commit borrows
the http error handling from the gitea driver and applies the
pattern to all of the other drivers.

Steps to reproduce:
Given an enterprise gitlab account, create:
- an access token that has only `read_user` permissions
- a private repo
Create a client using the above token.
Call the client's ListBranches method.

Expected:
an error that includes an indication that the client request was unauthorized/the http response status was 403.

Actual:
err.Error() = ""