### PR TITLE
fix: Gitlab pullrequests populates fork field

### DIFF
--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -419,6 +419,10 @@ func (s *pullService) convertPullRequest(ctx context.Context, from *pr) (*scm.Pu
 			return nil, res, err
 		}
 	}
+	sourceRepo, err := s.getSourceFork(ctx, from)
+	if err != nil {
+		return nil, res, err
+	}
 	return &scm.PullRequest{
 		Number:         from.Number,
 		Title:          from.Title,
@@ -449,7 +453,18 @@ func (s *pullService) convertPullRequest(ctx context.Context, from *pr) (*scm.Pu
 		},
 		Created: from.Created,
 		Updated: from.Updated,
+		Fork:    sourceRepo.PathNamespace,
 	}, nil, nil
+}
+
+func (s *pullService) getSourceFork(ctx context.Context, from *pr) (repository, error) {
+	path := fmt.Sprintf("api/v4/projects/%d", from.SourceProjectID)
+	sourceRepo := repository{}
+	_, err := s.client.do(ctx, "GET", path, nil, &sourceRepo)
+	if err != nil {
+		return repository{}, err
+	}
+	return sourceRepo, nil
 }
 
 func convertPullRequestLabels(from []*string) []*scm.Label {

--- a/scm/driver/gitlab/pr_test.go
+++ b/scm/driver/gitlab/pr_test.go
@@ -27,6 +27,13 @@ func TestPullFind(t *testing.T) {
 		File("testdata/repo.json")
 
 	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
 		Get("/api/v4/projects/diaspora/diaspora/merge_requests/1347").
 		Reply(200).
 		Type("application/json").
@@ -60,6 +67,13 @@ func TestPullFind(t *testing.T) {
 
 func TestPullList(t *testing.T) {
 	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
 
 	gock.New("https://gitlab.com").
 		Get("/api/v4/projects/32732").
@@ -378,6 +392,13 @@ func TestPullCreate(t *testing.T) {
 		File("testdata/other_repo.json")
 
 	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
+
+	gock.New("https://gitlab.com").
 		Post("/api/v4/projects/diaspora/diaspora/merge_requests").
 		Reply(201).
 		Type("application/json").
@@ -419,6 +440,13 @@ func TestPullUpdate(t *testing.T) {
 		Type("application/json").
 		SetHeaders(mockHeaders).
 		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
 
 	gock.New("https://gitlab.com").
 		Get("/api/v4/projects/2").
@@ -514,6 +542,13 @@ func TestPullSetMilestone(t *testing.T) {
 		File("testdata/other_repo.json")
 
 	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
+
+	gock.New("https://gitlab.com").
 		Put("/api/v4/projects/diaspora/diaspora/merge_requests/1").
 		File("testdata/issue_or_pr_set_milestone.json").
 		Reply(201).
@@ -537,6 +572,13 @@ func TestPullClearMilestone(t *testing.T) {
 		Type("application/json").
 		SetHeaders(mockHeaders).
 		File("testdata/repo.json")
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/2").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/other_repo.json")
 
 	gock.New("https://gitlab.com").
 		Get("/api/v4/projects/2").

--- a/scm/driver/gitlab/testdata/merge.json.golden
+++ b/scm/driver/gitlab/testdata/merge.json.golden
@@ -28,6 +28,7 @@
     }],
     "Created": "2015-12-18T18:29:53.563Z",
     "Updated": "2015-12-18T18:30:22.522Z",
+    "Fork": "diaspora/diaspora",
     "Head": {
         "Ref": "fix",
         "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",

--- a/scm/driver/gitlab/testdata/merges.json.golden
+++ b/scm/driver/gitlab/testdata/merges.json.golden
@@ -23,6 +23,7 @@
         },
         "Created": "2015-12-18T18:29:53.563Z",
         "Updated": "2015-12-18T18:30:22.522Z",
+        "Fork":   "diaspora/diaspora",
         "Head": {
             "Ref": "fix",
             "Sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",

--- a/scm/driver/gitlab/testdata/pr_create.json.golden
+++ b/scm/driver/gitlab/testdata/pr_create.json.golden
@@ -51,7 +51,7 @@
       "Updated": "0001-01-01T00:00:00Z"
     }
   },
-  "Fork": "",
+  "Fork": "diaspora/diaspora",
   "Link": "http://gitlab.example.com/my-group/my-project/merge_requests/1",
   "State": "closed",
   "Closed": true,


### PR DESCRIPTION
The gitlab driver populates the scm.PullRequest field `Fork`, but the Gitlab driver does not. This pr ensures that gitlab prs populate this field.

Note: In `scm/driver/gitlab/pr_test.go` I have duplicated instantiating a number of gock doubles, as there is a new http call in the `pr.go` implementation. This gock duplication feels clunky and if there is a better pattern for enabling this, I would be happy to follow it.