### PR TITLE
fix: Gitlab commits include url in `link` field

### DIFF
--- a/scm/driver/github/integration/git_test.go
+++ b/scm/driver/github/integration/git_test.go
@@ -226,5 +226,8 @@ func testCommit(commit *scm.Commit) func(t *testing.T) {
 		if got, want := commit.Committer.Date.Unix(), int64(1331075210); got != want {
 			t.Errorf("Want commit author Date %d, got %d", want, got)
 		}
+		if got, want := commit.Link, "https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"; got != want {
+			t.Errorf("Want commit link %q, got %q", want, got)
+		}
 	}
 }

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -134,6 +134,7 @@ type commit struct {
 	CommitterName  string    `json:"committer_name"`
 	CommitterEmail string    `json:"committer_email"`
 	Created        time.Time `json:"created_at"`
+	URL            string    `json:"web_url"`
 }
 
 func convertCommitList(from []*commit) []*scm.Commit {
@@ -148,6 +149,7 @@ func convertCommit(from *commit) *scm.Commit {
 	return &scm.Commit{
 		Message: from.Message,
 		Sha:     from.ID,
+		Link:    from.URL,
 		Author: scm.Signature{
 			Login: from.AuthorName,
 			Name:  from.AuthorName,

--- a/scm/driver/gitlab/integration/git_test.go
+++ b/scm/driver/gitlab/integration/git_test.go
@@ -210,5 +210,8 @@ func testCommit(commit *scm.Commit) func(t *testing.T) {
 		if got, want := commit.Committer.Date.Unix(), int64(1393489561); got != want {
 			t.Errorf("Want commit author Date %d, got %d", want, got)
 		}
+		if got, want := commit.Link, "https://gitlab.com/gitlab-org/testme/-/commit/0b4bc9a49b562e85de7cc9e834518ea6828729b9"; got != want {
+			t.Errorf("Want commit link %q, got %q", want, got)
+		}
 	}
 }


### PR DESCRIPTION
This was untestedin github. Test added.
This was untested and not implemented in gitlab. Implementation and test.