### PR TITLE
CompareCommits for diff between 2 commits

### DIFF
--- a/scm/client.go
+++ b/scm/client.go
@@ -73,6 +73,8 @@ type (
 		URL  string
 		Page int
 		Size int
+		From string
+		To   string
 	}
 
 	// GraphQLService the API to performing GraphQL queries

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -124,6 +124,17 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm
 	return convertDiffstats(out), res, err
 }
 
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	path := fmt.Sprintf("2.0/repositories/%s/diffstat/%s..%s?%s", repo, ref1, ref2, encodeListOptions(opts))
+	out := new(diffstats)
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	if err != nil {
+		return nil, res, err
+	}
+	err = copyPagination(out.pagination, res)
+	return convertDiffstats(out), res, err
+}
+
 type branch struct {
 	Type   string `json:"type"`
 	Name   string `json:"name"`

--- a/scm/driver/fake/git.go
+++ b/scm/driver/fake/git.go
@@ -59,6 +59,10 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm
 	panic("implement me")
 }
 
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	panic("implement me")
+}
+
 func (s *gitService) ListTags(ctx context.Context, repo string, opts scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	panic("implement me")
 }

--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -100,6 +100,10 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ scm.Li
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 //
 // native data structures
 //

--- a/scm/driver/gitea/git_test.go
+++ b/scm/driver/gitea/git_test.go
@@ -88,6 +88,14 @@ func TestChangeList(t *testing.T) {
 	}
 }
 
+func TestCompareCommits(t *testing.T) {
+	client, _ := New("https://try.gitea.io")
+	_, _, err := client.Git.CompareCommits(context.Background(), "go-gitea/gitea", "21cf205dc770d637a9ba636644cf8bf690cc100d", "63aeb0a859499623becc1d1e7c8a2ad57439e139",scm.ListOptions{})
+	if err != scm.ErrNotSupported {
+		t.Errorf("Expect Not Supported error")
+	}
+}
+
 //
 // branch sub-tests
 //

--- a/scm/driver/github/git.go
+++ b/scm/driver/github/git.go
@@ -108,6 +108,13 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ scm.Li
 	return convertChangeList(out.Files), res, err
 }
 
+func (s *gitService) ListChangesBetweenCommits(ctx context.Context, repo, ref1, ref2 string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	path := fmt.Sprintf("/repos/%s/compare/%s...%s", repo, ref1, ref2)
+	out := new(commit)
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	return convertChangeList(out.Files), res, err
+}
+
 type branch struct {
 	Name      string `json:"name"`
 	Commit    commit `json:"commit"`

--- a/scm/driver/github/git.go
+++ b/scm/driver/github/git.go
@@ -108,7 +108,7 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ scm.Li
 	return convertChangeList(out.Files), res, err
 }
 
-func (s *gitService) ListChangesBetweenCommits(ctx context.Context, repo, ref1, ref2 string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	path := fmt.Sprintf("/repos/%s/compare/%s...%s", repo, ref1, ref2)
 	out := new(commit)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/github/git_test.go
+++ b/scm/driver/github/git_test.go
@@ -218,7 +218,7 @@ func TestGitListChanges(t *testing.T) {
 	t.Run("Rate", testRate(res))
 }
 
-func TestGitListChangesBetweenCommits(t *testing.T) {
+func TestGitCompareCommits(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://api.github.com").
@@ -229,7 +229,7 @@ func TestGitListChangesBetweenCommits(t *testing.T) {
 		File("testdata/changes.json")
 
 	client := NewDefault()
-	got, res, err := client.Git.ListChangesBetweenCommits(context.Background(), "octocat/hello-world", "762941318ee16e59dabbacb1b4049eec22f0d303", "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d", scm.ListOptions{})
+	got, res, err := client.Git.CompareCommits(context.Background(), "octocat/hello-world", "762941318ee16e59dabbacb1b4049eec22f0d303", "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d", scm.ListOptions{})
 	if err != nil {
 		t.Error(err)
 		return

--- a/scm/driver/github/integration/git_test.go
+++ b/scm/driver/github/integration/git_test.go
@@ -195,10 +195,10 @@ func testChangeList(client *scm.Client) func(t *testing.T) {
 	}
 }
 
-func testChangeListBetweenCommits(client *scm.Client) func(t *testing.T) {
+func testCompareCommits(client *scm.Client) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		result, _, err := client.Git.ListChangesBetweenCommits(context.Background(), "ossu/computer-science", "f3e6b8608c05b6c2c21384de2c5dcca43f336ed0","a92b5077b4b0796b680d2a41472c594351ad3f35", scm.ListOptions{})
+		result, _, err := client.Git.CompareCommits(context.Background(), "ossu/computer-science", "f3e6b8608c05b6c2c21384de2c5dcca43f336ed0","a92b5077b4b0796b680d2a41472c594351ad3f35", scm.ListOptions{})
 		if err != nil {
 			t.Error(err)
 			return

--- a/scm/driver/github/integration/git_test.go
+++ b/scm/driver/github/integration/git_test.go
@@ -175,6 +175,44 @@ func testBranchCommitList(client *scm.Client) func(t *testing.T) {
 }
 
 //
+// change sub-tests
+//
+
+func testChangeList(client *scm.Client) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		result, _, err := client.Git.ListChanges(context.Background(), "ossu/computer-science", "a92b5077b4b0796b680d2a41472c594351ad3f35", scm.ListOptions{})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(result) == 0 {
+			t.Errorf("Want a non-empty change list")
+		}
+		for _, change := range result {
+			t.Run("Change", testCommitChange(change))
+		}
+	}
+}
+
+func testChangeListBetweenCommits(client *scm.Client) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		result, _, err := client.Git.ListChangesBetweenCommits(context.Background(), "ossu/computer-science", "f3e6b8608c05b6c2c21384de2c5dcca43f336ed0","a92b5077b4b0796b680d2a41472c594351ad3f35", scm.ListOptions{})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(result) == 0 {
+			t.Errorf("Want a non-empty change list")
+		}
+		for _, change := range result {
+			t.Run("Change", testCommitChange(change))
+		}
+	}
+}
+
+//
 // struct sub-tests
 //
 
@@ -228,6 +266,41 @@ func testCommit(commit *scm.Commit) func(t *testing.T) {
 		}
 		if got, want := commit.Link, "https://github.com/octocat/Hello-World/commit/7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"; got != want {
 			t.Errorf("Want commit link %q, got %q", want, got)
+		}
+	}
+}
+
+func testCommitChange(change *scm.Change) func(t *testing.T) {
+	return func(t *testing.T) {
+		if got, want := change.Path, "README.md"; got != want {
+			t.Errorf("Want commit Path %q, got %q", want, got)
+		}
+		if got, want := change.PreviousPath, ""; got != want {
+			t.Errorf("Want commit PreviousPath %q, got %q", want, got)
+		}
+		if got, want := change.Added, false; got != want {
+			t.Errorf("Want commit Added %t, got %t", want, got)
+		}
+		if got, want := change.Renamed, false; got != want {
+			t.Errorf("Want commit Renamed %t, got %t", want, got)
+		}
+		if got, want := change.Deleted, false; got != want {
+			t.Errorf("Want commit Deleted %t, got %t", want, got)
+		}
+		if got, want := change.Additions, 1; got != want {
+			t.Errorf("Want commit Additions %d, got %d", want, got)
+		}
+		if got, want := change.Deletions, 1; got != want {
+			t.Errorf("Want commit Deletions %d, got %d", want, got)
+		}
+		if got, want := change.Changes, 2; got != want {
+			t.Errorf("Want commit Changes %d, got %d", want, got)
+		}
+		if got, want := change.BlobURL, "https://github.com/ossu/computer-science/blob/a92b5077b4b0796b680d2a41472c594351ad3f35/README.md"; got != want {
+			t.Errorf("Want commit BlobURL %q, got %q", want, got)
+		}
+		if got, want := change.Sha, "487f3788c10aa8367e2a299dbdc06da48e709baa"; got != want {
+			t.Errorf("Want commit Sha %q, got %q", want, got)
 		}
 	}
 }

--- a/scm/driver/github/integration/github_test.go
+++ b/scm/driver/github/integration/github_test.go
@@ -33,4 +33,6 @@ func TestGitHub(t *testing.T) {
 	t.Run("PullRequests", testPullRequests(client))
 	t.Run("Repositories", testRepos(client))
 	t.Run("Users", testUsers(client))
+	t.Run("Changes", testChangeList(client))
+	t.Run("ChangesBetweenCommits", testChangeListBetweenCommits(client))
 }

--- a/scm/driver/github/integration/github_test.go
+++ b/scm/driver/github/integration/github_test.go
@@ -34,5 +34,5 @@ func TestGitHub(t *testing.T) {
 	t.Run("Repositories", testRepos(client))
 	t.Run("Users", testUsers(client))
 	t.Run("Changes", testChangeList(client))
-	t.Run("ChangesBetweenCommits", testChangeListBetweenCommits(client))
+	t.Run("CompareCommits", testCompareCommits(client))
 }

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -117,7 +117,9 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm
 }
 
 func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/repository/compare?from=%s&to=%s", encode(repo), encode(ref1), encode(ref2))
+	opts.From = encode(ref1)
+	opts.To = encode(ref2)
+	path := fmt.Sprintf("api/v4/projects/%s/repository/compare?%s", encode(repo), encodeListOptions(opts))
 	out := compare{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertChangeList(out.Diffs), res, err

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -116,7 +116,7 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm
 	return convertChangeList(out), res, err
 }
 
-func (s *gitService) ListChangesBetweenCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
 	path := fmt.Sprintf("api/v4/projects/%s/repository/compare?from=%s&to=%s", encode(repo), encode(ref1), encode(ref2))
 	out := compare{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -116,6 +116,17 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm
 	return convertChangeList(out), res, err
 }
 
+func (s *gitService) ListChangesBetweenCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	path := fmt.Sprintf("api/v4/projects/%s/repository/compare?from=%s&to=%s", encode(repo), encode(ref1), encode(ref2))
+	out := compare{}
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	return convertChangeList(out.Diffs), res, err
+}
+
+type compare struct {
+	Diffs []*change `json:"diffs"`
+}
+
 type branch struct {
 	Name   string `json:"name"`
 	Commit struct {

--- a/scm/driver/gitlab/git_test.go
+++ b/scm/driver/gitlab/git_test.go
@@ -244,7 +244,7 @@ func TestGitListChanges(t *testing.T) {
 	t.Run("Rate", testRate(res))
 }
 
-func TestGitListChangesBetweenCommits(t *testing.T) {
+func TestGitCompareCommits(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://gitlab.com").
@@ -257,7 +257,7 @@ func TestGitListChangesBetweenCommits(t *testing.T) {
 		File("testdata/compare.json")
 
 	client := NewDefault()
-	got, res, err := client.Git.ListChangesBetweenCommits(context.Background(), "gitterHQ/webapp", "6da006adb7cafe15b8495e3b7811fc318e485553", "c5895070235cadd2d839136dad79e01838ee2de1", scm.ListOptions{})
+	got, res, err := client.Git.CompareCommits(context.Background(), "gitterHQ/webapp", "6da006adb7cafe15b8495e3b7811fc318e485553", "c5895070235cadd2d839136dad79e01838ee2de1", scm.ListOptions{})
 	if err != nil {
 		t.Error(err)
 		return

--- a/scm/driver/gitlab/git_test.go
+++ b/scm/driver/gitlab/git_test.go
@@ -244,6 +244,38 @@ func TestGitListChanges(t *testing.T) {
 	t.Run("Rate", testRate(res))
 }
 
+func TestGitListChangesBetweenCommits(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/gitterHQ/webapp/repository/compare").
+		MatchParam("from", "6da006adb7cafe15b8495e3b7811fc318e485553").
+		MatchParam("to", "c5895070235cadd2d839136dad79e01838ee2de1").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/compare.json")
+
+	client := NewDefault()
+	got, res, err := client.Git.ListChangesBetweenCommits(context.Background(), "gitterHQ/webapp", "6da006adb7cafe15b8495e3b7811fc318e485553", "c5895070235cadd2d839136dad79e01838ee2de1", scm.ListOptions{})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	want := []*scm.Change{}
+	raw, _ := ioutil.ReadFile("testdata/compare.json.golden")
+	json.Unmarshal(raw, &want)
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+
+	t.Run("Request", testRequest(res))
+	t.Run("Rate", testRate(res))
+}
+
 func TestGitCreateRef(t *testing.T) {
 	baseSHA := "aa218f56b14c9653891f9e74264a383fa43fefbd"
 	defer gock.Off()

--- a/scm/driver/gitlab/integration/git_test.go
+++ b/scm/driver/gitlab/integration/git_test.go
@@ -159,6 +159,44 @@ func testCommitList(client *scm.Client) func(t *testing.T) {
 }
 
 //
+// change sub-tests
+//
+
+func testChangeList(client *scm.Client) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		result, _, err := client.Git.ListChanges(context.Background(), "gitterHQ/webapp", "c5895070235cadd2d839136dad79e01838ee2de1", scm.ListOptions{})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(result) == 0 {
+			t.Errorf("Want a non-empty change list")
+		}
+		for _, change := range result {
+			t.Run("Change", testCommitChange(change))
+		}
+	}
+}
+
+func testChangeListBetweenCommits(client *scm.Client) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Parallel()
+		result, _, err := client.Git.ListChangesBetweenCommits(context.Background(), "gitterHQ/webapp", "6da006adb7cafe15b8495e3b7811fc318e485553","c5895070235cadd2d839136dad79e01838ee2de1", scm.ListOptions{})
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		if len(result) == 0 {
+			t.Errorf("Want a non-empty change list")
+		}
+		for _, change := range result {
+			t.Run("Change", testCommitChange(change))
+		}
+	}
+}
+
+//
 // struct sub-tests
 //
 
@@ -212,6 +250,26 @@ func testCommit(commit *scm.Commit) func(t *testing.T) {
 		}
 		if got, want := commit.Link, "https://gitlab.com/gitlab-org/testme/-/commit/0b4bc9a49b562e85de7cc9e834518ea6828729b9"; got != want {
 			t.Errorf("Want commit link %q, got %q", want, got)
+		}
+	}
+}
+
+func testCommitChange(change *scm.Change) func(t *testing.T) {
+	return func(t *testing.T) {
+		if got, want := change.Path, "config/config.prod.json"; got != want {
+			t.Errorf("Want commit Path %q, got %q", want, got)
+		}
+		if got, want := change.PreviousPath, "config/config.prod.json"; got != want {
+			t.Errorf("Want commit PreviousPath %q, got %q", want, got)
+		}
+		if got, want := change.Added, false; got != want {
+			t.Errorf("Want commit Added %t, got %t", want, got)
+		}
+		if got, want := change.Renamed, false; got != want {
+			t.Errorf("Want commit Renamed %t, got %t", want, got)
+		}
+		if got, want := change.Deleted, false; got != want {
+			t.Errorf("Want commit Deleted %t, got %t", want, got)
 		}
 	}
 }

--- a/scm/driver/gitlab/integration/git_test.go
+++ b/scm/driver/gitlab/integration/git_test.go
@@ -179,10 +179,10 @@ func testChangeList(client *scm.Client) func(t *testing.T) {
 	}
 }
 
-func testChangeListBetweenCommits(client *scm.Client) func(t *testing.T) {
+func testCompareCommits(client *scm.Client) func(t *testing.T) {
 	return func(t *testing.T) {
 		t.Parallel()
-		result, _, err := client.Git.ListChangesBetweenCommits(context.Background(), "gitterHQ/webapp", "6da006adb7cafe15b8495e3b7811fc318e485553","c5895070235cadd2d839136dad79e01838ee2de1", scm.ListOptions{})
+		result, _, err := client.Git.CompareCommits(context.Background(), "gitterHQ/webapp", "6da006adb7cafe15b8495e3b7811fc318e485553","c5895070235cadd2d839136dad79e01838ee2de1", scm.ListOptions{})
 		if err != nil {
 			t.Error(err)
 			return

--- a/scm/driver/gitlab/integration/gitlab_test.go
+++ b/scm/driver/gitlab/integration/gitlab_test.go
@@ -34,5 +34,5 @@ func TestGitLab(t *testing.T) {
 	t.Run("Repositories", testRepos(client))
 	t.Run("Users", testUsers(client))
 	t.Run("Changes", testChangeList(client))
-	t.Run("ChangesBetweenCommits", testChangeListBetweenCommits(client))
+	t.Run("CompareCommits", testCompareCommits(client))
 }

--- a/scm/driver/gitlab/integration/gitlab_test.go
+++ b/scm/driver/gitlab/integration/gitlab_test.go
@@ -33,4 +33,6 @@ func TestGitLab(t *testing.T) {
 	t.Run("PullRequests", testPullRequests(client))
 	t.Run("Repositories", testRepos(client))
 	t.Run("Users", testUsers(client))
+	t.Run("Changes", testChangeList(client))
+	t.Run("ChangesBetweenCommits", testChangeListBetweenCommits(client))
 }

--- a/scm/driver/gitlab/testdata/compare.json
+++ b/scm/driver/gitlab/testdata/compare.json
@@ -1,0 +1,71 @@
+{
+  "commit": {
+    "id": "c5895070235cadd2d839136dad79e01838ee2de1",
+    "short_id": "c5895070",
+    "created_at": "2020-12-01T18:19:27.000+00:00",
+    "parent_ids": [
+      "6da006adb7cafe15b8495e3b7811fc318e485553",
+      "6d0ad7cf742dfe26694cc515a6d8dea7e897e84c"
+    ],
+    "title": "Merge branch 'allow-all-rooms-to-bridge-in-production' into 'develop'",
+    "message": "Merge branch 'allow-all-rooms-to-bridge-in-production' into 'develop'\n\nRemove room restriction on production Matrix bridge\n\nSee merge request gitterHQ/webapp!2085",
+    "author_name": "Eric Eastwood",
+    "author_email": "contact@ericeastwood.com",
+    "authored_date": "2020-12-01T18:19:27.000+00:00",
+    "committer_name": "Eric Eastwood",
+    "committer_email": "contact@ericeastwood.com",
+    "committed_date": "2020-12-01T18:19:27.000+00:00",
+    "web_url": "https://gitlab.com/gitterHQ/webapp/-/commit/c5895070235cadd2d839136dad79e01838ee2de1"
+  },
+  "commits": [
+    {
+      "id": "6d0ad7cf742dfe26694cc515a6d8dea7e897e84c",
+      "short_id": "6d0ad7cf",
+      "created_at": "2020-12-01T11:19:50.000-06:00",
+      "parent_ids": [
+        "0f230e782a30060224c68b3e0a2cd9841f1a4249"
+      ],
+      "title": "Remove room restriction on production bridge",
+      "message": "Remove room restriction on production bridge\n\nPart of https://gitlab.com/gitterHQ/webapp/-/issues/1684\n",
+      "author_name": "Eric Eastwood",
+      "author_email": "contact@ericeastwood.com",
+      "authored_date": "2020-12-01T11:19:50.000-06:00",
+      "committer_name": "Eric Eastwood",
+      "committer_email": "contact@ericeastwood.com",
+      "committed_date": "2020-12-01T11:19:50.000-06:00",
+      "web_url": "https://gitlab.com/gitterHQ/webapp/-/commit/6d0ad7cf742dfe26694cc515a6d8dea7e897e84c"
+    },
+    {
+      "id": "c5895070235cadd2d839136dad79e01838ee2de1",
+      "short_id": "c5895070",
+      "created_at": "2020-12-01T18:19:27.000+00:00",
+      "parent_ids": [
+        "6da006adb7cafe15b8495e3b7811fc318e485553",
+        "6d0ad7cf742dfe26694cc515a6d8dea7e897e84c"
+      ],
+      "title": "Merge branch 'allow-all-rooms-to-bridge-in-production' into 'develop'",
+      "message": "Merge branch 'allow-all-rooms-to-bridge-in-production' into 'develop'\n\nRemove room restriction on production Matrix bridge\n\nSee merge request gitterHQ/webapp!2085",
+      "author_name": "Eric Eastwood",
+      "author_email": "contact@ericeastwood.com",
+      "authored_date": "2020-12-01T18:19:27.000+00:00",
+      "committer_name": "Eric Eastwood",
+      "committer_email": "contact@ericeastwood.com",
+      "committed_date": "2020-12-01T18:19:27.000+00:00",
+      "web_url": "https://gitlab.com/gitterHQ/webapp/-/commit/c5895070235cadd2d839136dad79e01838ee2de1"
+    }
+  ],
+  "diffs": [
+    {
+      "old_path": "config/config.prod.json",
+      "new_path": "config/config.prod.json",
+      "a_mode": "100644",
+      "b_mode": "100644",
+      "new_file": false,
+      "renamed_file": false,
+      "deleted_file": false,
+      "diff": "@@ -52,11 +52,7 @@\n       \"homeserverUrl\": \"https://gitter.ems.host\",\n       \"serverName\": \"gitter.im\",\n       \"applicationServiceUrl\": \"https://matrix.gitter.im\",\n-      \"senderLocalpart\": \"matrixbot\",\n-      \"gitterRoomAllowList\": [\n-        \"5faa0809d73408ce4ff3ad8e\",\n-        \"5faa0a0ed73408ce4ff3ada9\"\n-      ]\n+      \"senderLocalpart\": \"matrixbot\"\n     }\n   },\n   \"virtualUsers\": {\n"
+    }
+  ],
+  "compare_timeout": false,
+  "compare_same_ref": false
+}

--- a/scm/driver/gitlab/testdata/compare.json.golden
+++ b/scm/driver/gitlab/testdata/compare.json.golden
@@ -1,0 +1,10 @@
+[
+    {
+        "PreviousPath": "config/config.prod.json",
+        "Path": "config/config.prod.json",
+        "Added": false,
+        "Renamed": false,
+        "Deleted": false,
+        "Patch": "@@ -52,11 +52,7 @@\n       \"homeserverUrl\": \"https://gitter.ems.host\",\n       \"serverName\": \"gitter.im\",\n       \"applicationServiceUrl\": \"https://matrix.gitter.im\",\n-      \"senderLocalpart\": \"matrixbot\",\n-      \"gitterRoomAllowList\": [\n-        \"5faa0809d73408ce4ff3ad8e\",\n-        \"5faa0a0ed73408ce4ff3ada9\"\n-      ]\n+      \"senderLocalpart\": \"matrixbot\"\n     }\n   },\n   \"virtualUsers\": {\n"
+    }
+]

--- a/scm/driver/gitlab/util.go
+++ b/scm/driver/gitlab/util.go
@@ -24,6 +24,12 @@ func encodeListOptions(opts scm.ListOptions) string {
 	if opts.Size != 0 {
 		params.Set("per_page", strconv.Itoa(opts.Size))
 	}
+	if opts.From != "" {
+		params.Set("from",opts.From)
+	}
+	if opts.To != "" {
+		params.Set("to",opts.To)
+	}
 	return params.Encode()
 }
 

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -65,6 +65,10 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, _ scm.Li
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, _ scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 //
 // native data structures
 //

--- a/scm/driver/gogs/git_test.go
+++ b/scm/driver/gogs/git_test.go
@@ -60,6 +60,14 @@ func TestChangeList(t *testing.T) {
 	}
 }
 
+func TestCompareCommits(t *testing.T) {
+	client, _ := New("https://try.gogs.io")
+	_, _, err := client.Git.CompareCommits(context.Background(), "gogits/gogs", "f05f642b892d59a0a9ef6a31f6c905a24b5db13a", "atotallydifferentshaofexactlysamelengths", scm.ListOptions{})
+	if err != scm.ErrNotSupported {
+		t.Errorf("Expect Not Supported error")
+	}
+}
+
 //
 // branch sub-tests
 //

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -128,6 +128,20 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts scm
 	return convertDiffstats(out), res, err
 }
 
+func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts scm.ListOptions) ([]*scm.Change, *scm.Response, error) {
+	namespace, name := scm.Split(repo)
+	opts.From = url.PathEscape(ref1)
+	opts.To = url.PathEscape(ref2)
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/compare/changes?%s", namespace, name, encodeListOptions(opts))
+	out := new(diffstats)
+	res, err := s.client.do(ctx, "GET", path, nil, &out)
+	if !out.pagination.LastPage.Bool {
+		res.Page.First = 1
+		res.Page.Next = opts.Page + 1
+	}
+	return convertDiffstats(out), res, err
+}
+
 type branch struct {
 	ID              string `json:"id"`
 	DisplayID       string `json:"displayId"`

--- a/scm/driver/stash/util.go
+++ b/scm/driver/stash/util.go
@@ -21,6 +21,12 @@ func encodeListOptions(opts scm.ListOptions) string {
 	if opts.Size != 0 {
 		params.Set("limit", strconv.Itoa(opts.Size))
 	}
+	if opts.From != "" {
+		params.Set("from",opts.From)
+	}
+	if opts.To != "" {
+		params.Set("to",opts.To)
+	}
 	return params.Encode()
 }
 

--- a/scm/git.go
+++ b/scm/git.go
@@ -74,8 +74,11 @@ type (
 		// ListCommits returns a list of git commits.
 		ListCommits(ctx context.Context, repo string, opts CommitListOptions) ([]*Commit, *Response, error)
 
-		// ListChanges returns the changeset between two commits.
+		// ListChanges returns the changeset between a commit and its parent.
 		ListChanges(ctx context.Context, repo, ref string, opts ListOptions) ([]*Change, *Response, error)
+
+		// ListChanges returns the changeset between two commits.
+		ListChangesBetweenCommits(ctx context.Context, repo, ref1, ref2 string, opts ListOptions) ([]*Change, *Response, error)
 
 		// ListTags returns a list of git tags.
 		ListTags(ctx context.Context, repo string, opts ListOptions) ([]*Reference, *Response, error)

--- a/scm/git.go
+++ b/scm/git.go
@@ -78,7 +78,7 @@ type (
 		ListChanges(ctx context.Context, repo, ref string, opts ListOptions) ([]*Change, *Response, error)
 
 		// ListChanges returns the changeset between two commits.
-		ListChangesBetweenCommits(ctx context.Context, repo, ref1, ref2 string, opts ListOptions) ([]*Change, *Response, error)
+		CompareCommits(ctx context.Context, repo, ref1, ref2 string, opts ListOptions) ([]*Change, *Response, error)
 
 		// ListTags returns a list of git tags.
 		ListTags(ctx context.Context, repo string, opts ListOptions) ([]*Reference, *Response, error)


### PR DESCRIPTION
ListChanges only shows the changes between a commit and its parent.
Viewing changes between a commit and another commit is useful.
The feature is supported by a number of the cloud repository providers
(github, gitlab, bitbucket).