### PR TITLE
fix: need to also return a 404 not found go error in the workaround

### DIFF
--- a/scm/driver/gitea/release.go
+++ b/scm/driver/gitea/release.go
@@ -28,7 +28,7 @@ func (s *releaseService) FindByTag(ctx context.Context, repo string, tag string)
 				Status: 404,
 				Header: resp.Header,
 				Body:   resp.Body,
-			}, nil
+			}, scm.ErrNotFound
 		}
 	}
 	return convertRelease(out), toSCMResponse(resp), err


### PR DESCRIPTION
this is also needed for the workaround to work.