### PR TITLE
fix: Update Gitlab Webhook Service to Fetch Users By ID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.3.0
 	github.com/mitchellh/copystructure v1.0.0
-	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/shurcooL/githubv4 v0.0.0-20190718010115-4ba037080260
 	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f
@@ -18,4 +17,3 @@ require (
 )
 
 go 1.13
-

--- a/scm/driver/gitlab/gitlab.go
+++ b/scm/driver/gitlab/gitlab.go
@@ -23,7 +23,7 @@ import (
 
 // NewWebHookService creates a new instance of the webhook service without the rest of the client
 func NewWebHookService() scm.WebhookService {
-	return &webhookService{nil}
+	return &webhookService{nil, nil}
 }
 
 // New returns a new GitLab API client.
@@ -48,8 +48,14 @@ func New(uri string) (*scm.Client, error) {
 	client.PullRequests = &pullService{client}
 	client.Repositories = &repositoryService{client}
 	client.Reviews = &reviewService{client}
-	client.Users = &userService{client}
-	client.Webhooks = &webhookService{client}
+
+	//add the user service to the webhook service so it can be used for fetching users
+	us := &userService{client}
+	client.Users = us
+	client.Webhooks = &webhookService{
+		client:      client,
+		userService: us,
+	}
 
 	graphqlEndpoint := scm.URLJoin(uri, "/api/graphql")
 	client.GraphQLURL, err = url.Parse(graphqlEndpoint)

--- a/scm/driver/gitlab/user.go
+++ b/scm/driver/gitlab/user.go
@@ -7,6 +7,7 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -54,6 +55,20 @@ func (s *userService) FindLogin(ctx context.Context, login string) (*scm.User, *
 		opts.Page++
 	}
 	return nil, resp, scm.ErrNotFound
+}
+
+// FindLoginByID returns the scm.User object for the specified user id
+func (s *userService) FindLoginByID(ctx context.Context, id int) (*scm.User, error) {
+	path := fmt.Sprintf("api/v4/users/%d", id)
+	out := &user{}
+	resp, err := s.client.do(ctx, "GET", path, nil, &out)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Status == http.StatusOK {
+		return convertUser(out), err
+	}
+	return nil, scm.ErrNotFound
 }
 
 func (s *userService) FindEmail(ctx context.Context) (string, *scm.Response, error) {

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -5,6 +5,7 @@
 package gitlab
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -19,6 +20,13 @@ import (
 
 type webhookService struct {
 	client *wrapper
+	//need the user service as well
+	userService webhookUserService
+}
+
+// an interface to provide a find login by id in gitlab
+type webhookUserService interface {
+	FindLoginByID(ctx context.Context, id int) (*scm.User, error)
 }
 
 func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhook, error) {
@@ -39,7 +47,7 @@ func (s *webhookService) Parse(req *http.Request, fn scm.SecretFunc) (scm.Webhoo
 	case "Merge Request Hook":
 		hook, err = parsePullRequestHook(data)
 	case "Note Hook":
-		hook, err = parseCommentHook(data)
+		hook, err = parseCommentHook(s, data)
 	default:
 		return nil, scm.UnknownWebhook{Event: event}
 	}
@@ -111,7 +119,7 @@ func parsePullRequestHook(data []byte) (scm.Webhook, error) {
 	}
 }
 
-func parseCommentHook(data []byte) (scm.Webhook, error) {
+func parseCommentHook(s *webhookService, data []byte) (scm.Webhook, error) {
 	src := new(commentHook)
 	err := json.Unmarshal(data, src)
 	if err != nil {
@@ -123,7 +131,7 @@ func parseCommentHook(data []byte) (scm.Webhook, error) {
 	kind := src.ObjectAttributes.NoteableType
 	switch kind {
 	case "MergeRequest":
-		return convertMergeRequestCommentHook(src), nil
+		return convertMergeRequestCommentHook(s, src)
 	default:
 		return nil, scm.UnknownWebhook{Event: kind}
 	}
@@ -285,13 +293,18 @@ func convertPullRequestHook(src *pullRequestHook) *scm.PullRequestHook {
 	}
 }
 
-func convertMergeRequestCommentHook(src *commentHook) *scm.PullRequestCommentHook {
-	user := scm.User{
-		ID:     src.ObjectAttributes.AuthorID,
-		Login:  src.User.Username,
-		Name:   src.User.Name,
-		Email:  "", // TODO how do we get the pull request author email?
-		Avatar: src.User.AvatarURL,
+func convertMergeRequestCommentHook(s *webhookService, src *commentHook) (*scm.PullRequestCommentHook, error) {
+
+	// There are two users needed here: the comment author and the MergeRequest author.
+	// Since we only have the user name, we need to use the user service to fetch these.
+	commentAuthor, err := s.userService.FindLoginByID(context.TODO(), src.ObjectAttributes.AuthorID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find comment author %w", err)
+	}
+
+	mrAuthor, err := s.userService.FindLoginByID(context.TODO(), src.MergeRequest.AuthorID)
+	if err != nil {
+		return nil, fmt.Errorf("unable to find mr author %w", err)
 	}
 
 	fork := scm.Join(
@@ -329,7 +342,7 @@ func convertMergeRequestCommentHook(src *commentHook) *scm.PullRequestCommentHoo
 		Merged:  src.MergeRequest.State == "merged",
 		Created: prCreatedAt,
 		Updated: prUpdatedAt, // 2017-12-10 17:01:11 UTC
-		Author:  user,
+		Author:  *mrAuthor,
 	}
 	pr.Base.Repo = *convertRepositoryHook(src.MergeRequest.Target)
 	pr.Head.Repo = *convertRepositoryHook(src.MergeRequest.Source)
@@ -337,19 +350,20 @@ func convertMergeRequestCommentHook(src *commentHook) *scm.PullRequestCommentHoo
 	createdAt, _ := time.Parse("2006-01-02 15:04:05 MST", src.ObjectAttributes.CreatedAt)
 	updatedAt, _ := time.Parse("2006-01-02 15:04:05 MST", src.ObjectAttributes.UpdatedAt)
 
-	return &scm.PullRequestCommentHook{
+	hook := &scm.PullRequestCommentHook{
 		Action:      scm.ActionCreate,
 		Repo:        repo,
 		PullRequest: pr,
 		Comment: scm.Comment{
 			ID:      src.ObjectAttributes.ID,
 			Body:    src.ObjectAttributes.Note,
-			Author:  user, // TODO: is the user the author id ??
+			Author:  *commentAuthor,
 			Created: createdAt,
 			Updated: updatedAt,
 		},
-		Sender: user,
+		Sender: *commentAuthor,
 	}
+	return hook, nil
 }
 
 func convertRepositoryHook(from *project) *scm.Repository {


### PR DESCRIPTION
Currently, when the `convertMergeRequestCommentHook` method runs, it builds up a user object based on a single ID and uses that both in the PR object and the comment object. This results in Lighthouse not properly handling any `/lgtm` in comments, as the author is the same as the user leaving the comment. ref https://github.com/jenkins-x/lighthouse/issues/1154


This PR adds a simple method to the user service to fetch by ID (which is present in the incoming webhook payload), and an interface for use within the `webhookService`. 

Fixes: #211

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>