### PR TITLE
fix: gitlab pushHook, add after field from webhook

### DIFF
--- a/scm/driver/gitlab/testdata/webhooks/branch_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/branch_create.json.golden
@@ -1,5 +1,6 @@
 {
     "Ref": "refs/heads/feature",
+    "After": "c4c79227ed610f1151f05bbc5be33b4f340d39c8",
     "Repo": {
         "ID": "4861503",
         "Namespace": "gitlab-org",

--- a/scm/driver/gitlab/testdata/webhooks/push.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/push.json.golden
@@ -1,5 +1,6 @@
 {
     "Ref": "refs/heads/master",
+    "After": "2adc9465c4edfc33834e173fe89436a7cb899a1d",
     "Repo": {
         "ID": "4861503",
         "Namespace": "gitlab-org",

--- a/scm/driver/gitlab/testdata/webhooks/tag_create.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/tag_create.json.golden
@@ -1,5 +1,6 @@
 {
     "Ref": "refs/tags/v1.0.0",
+    "After": "2adc9465c4edfc33834e173fe89436a7cb899a1d",
     "Repo": {
         "ID": "4861503",
         "Namespace": "gitlab-org",

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -142,6 +142,7 @@ func convertPushHook(src *pushHook) *scm.PushHook {
 	dst := &scm.PushHook{
 		Ref:  scm.ExpandRef(src.Ref, "refs/heads/"),
 		Repo: repo,
+		After: src.After,
 		Commit: scm.Commit{
 			Sha:     src.CheckoutSha,
 			Message: "", // NOTE this is set below


### PR DESCRIPTION
When convert a push webhook from gitlab, we forgot add the After field. We use this field in the creation of the lighthouse jobs (we use after as head).