### PR TITLE
fix: release webhook support

### DIFF
--- a/scm/driver/fake/release.go
+++ b/scm/driver/fake/release.go
@@ -3,6 +3,7 @@ package fake
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/jenkins-x/go-scm/scm"
 )
@@ -55,6 +56,7 @@ func (r *releaseService) List(_ context.Context, repo string, options scm.Releas
 func (r *releaseService) Create(_ context.Context, repo string, input *scm.ReleaseInput) (*scm.Release, *scm.Response, error) {
 	m := r.releaseMap(repo)
 	id := len(m)
+	now := time.Now()
 	release := &scm.Release{
 		ID:          id,
 		Title:       input.Title,
@@ -64,6 +66,8 @@ func (r *releaseService) Create(_ context.Context, repo string, input *scm.Relea
 		Commitish:   input.Commitish,
 		Draft:       input.Draft,
 		Prerelease:  input.Prerelease,
+		Created:     now,
+		Published:   now,
 	}
 	m[id] = release
 	return release, nil, nil

--- a/scm/driver/gitea/release.go
+++ b/scm/driver/gitea/release.go
@@ -146,8 +146,8 @@ func ConvertAPIURLToHTMLURL(apiURL string, tagName string) string {
 	return link.String()
 
 }
-func convertRelease(from *gitea.Release) *scm.Release {
 
+func convertRelease(from *gitea.Release) *scm.Release {
 	return &scm.Release{
 		ID:          int(from.ID),
 		Title:       from.Title,
@@ -158,6 +158,8 @@ func convertRelease(from *gitea.Release) *scm.Release {
 		Commitish:  from.Target,
 		Draft:      from.IsDraft,
 		Prerelease: from.IsPrerelease,
+		Created:    from.CreatedAt,
+		Published:  from.PublishedAt,
 	}
 }
 

--- a/scm/driver/gitea/testdata/webhooks/release.json
+++ b/scm/driver/gitea/testdata/webhooks/release.json
@@ -1,0 +1,53 @@
+{
+  "release": {
+    "id": 1,
+    "name": "v1.0.0",
+    "body": "Description of the release",
+    "url": "https://try.gitea.com/api/v1/repos/gogits/hello-world/123",
+    "tag_name": "v1.0.0",
+    "target_commitish": "master",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2017-12-10T01:30:43Z",
+    "published_at": "2017-12-10T01:30:43Z"
+  },
+  "repository": {
+    "id": 61,
+    "owner": {
+      "id": 25,
+      "login": "gogits",
+      "full_name": "",
+      "email": "",
+      "avatar_url": "http://try.gitea.io/avatars/25",
+      "username": "gogits"
+    },
+    "name": "hello-world",
+    "full_name": "gogits/hello-world",
+    "description": "",
+    "private": true,
+    "fork": false,
+    "parent": null,
+    "empty": false,
+    "mirror": false,
+    "size": 24576,
+    "html_url": "http://try.gitea.io/gogits/hello-world",
+    "ssh_url": "git@localhost:gogits/hello-world.git",
+    "clone_url": "http://try.gitea.io/gogits/hello-world.git",
+    "website": "",
+    "stars_count": 0,
+    "forks_count": 0,
+    "watchers_count": 2,
+    "open_issues_count": 0,
+    "default_branch": "master",
+    "created_at": "2017-12-09T01:30:43Z",
+    "updated_at": "2017-12-09T01:33:08Z"
+  },
+  "sender": {
+    "id": 1,
+    "login": "unknwon",
+    "full_name": "",
+    "email": "noreply@gogs.io",
+    "avatar_url": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87",
+    "username": "unknwon"
+  }
+}

--- a/scm/driver/gitea/testdata/webhooks/release.json.golden
+++ b/scm/driver/gitea/testdata/webhooks/release.json.golden
@@ -1,0 +1,35 @@
+{
+  "Repo": {
+    "ID": "61",
+    "Namespace": "gogits",
+    "Name": "hello-world",
+    "FullName": "gogits/hello-world",
+    "Branch": "master",
+    "Private": true,
+    "Clone": "http://try.gitea.io/gogits/hello-world.git",
+    "CloneSSH": "git@localhost:gogits/hello-world.git",
+    "Link": "http://try.gitea.io/gogits/hello-world",
+    "Created": "2017-12-09T01:30:43Z",
+    "Updated": "2017-12-09T01:33:08Z"
+  },
+  "Release": {
+    "ID": 1,
+    "Title": "v1.0.0",
+    "Description": "Description of the release",
+    "Link": "https://try.gitea.com/gogits/hello-world/releases/tag/v1.0.0",
+    "Tag": "v1.0.0",
+    "Commitish": "master",
+    "Draft": false,
+    "Prerelease": false,
+    "Created": "2017-12-10T01:30:43Z",
+    "Published": "2017-12-10T01:30:43Z"
+  },
+  "Sender": {
+    "ID": 1,
+    "Login": "unknwon",
+    "Name": "",
+    "Email": "noreply@gogs.io",
+    "Avatar": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
+  },
+  "Guid": "ee8d97b4-1479-43f1-9cac-fbbd1b80da55"
+}

--- a/scm/driver/gitea/webhook_test.go
+++ b/scm/driver/gitea/webhook_test.go
@@ -123,6 +123,13 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/review_approved.json.golden",
 			obj:    new(scm.ReviewHook),
 		},
+		// release hooks
+		{
+			event:  "release",
+			before: "testdata/webhooks/release.json",
+			after:  "testdata/webhooks/release.json.golden",
+			obj:    new(scm.ReleaseHook),
+		},
 	}
 
 	for _, test := range tests {

--- a/scm/driver/github/release.go
+++ b/scm/driver/github/release.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jenkins-x/go-scm/scm"
 )
@@ -12,14 +13,16 @@ type releaseService struct {
 }
 
 type release struct {
-	ID          int    `json:"id"`
-	Title       string `json:"name"`
-	Description string `json:"body"`
-	Link        string `json:"html_url,omitempty"`
-	Tag         string `json:"tag_name,omitempty"`
-	Commitish   string `json:"target_commitish,omitempty"`
-	Draft       bool   `json:"draft"`
-	Prerelease  bool   `json:"prerelease"`
+	ID          int       `json:"id"`
+	Title       string    `json:"name"`
+	Description string    `json:"body"`
+	Link        string    `json:"html_url,omitempty"`
+	Tag         string    `json:"tag_name,omitempty"`
+	Commitish   string    `json:"target_commitish,omitempty"`
+	Draft       bool      `json:"draft"`
+	Prerelease  bool      `json:"prerelease"`
+	Created     time.Time `json:"created_at"`
+	Published   time.Time `json:"published_at"`
 }
 
 type releaseInput struct {
@@ -122,5 +125,7 @@ func convertRelease(from *release) *scm.Release {
 		Commitish:   from.Commitish,
 		Draft:       from.Draft,
 		Prerelease:  from.Prerelease,
+		Created:     from.Created,
+		Published:   from.Published,
 	}
 }

--- a/scm/driver/github/testdata/release.json.golden
+++ b/scm/driver/github/testdata/release.json.golden
@@ -6,5 +6,7 @@
   "Tag": "v1.0.0",
   "Commitish": "master",
   "Draft": false,
-  "Prerelease": false
+  "Prerelease": false,
+  "Created": "2013-02-27T19:35:32Z",
+  "Published": "2013-02-27T19:35:32Z"
 }

--- a/scm/driver/github/testdata/releases.json.golden
+++ b/scm/driver/github/testdata/releases.json.golden
@@ -7,6 +7,8 @@
     "Tag": "v1.0.0",
     "Commitish": "master",
     "Draft": false,
-    "Prerelease": false
+    "Prerelease": false,
+    "Created": "2013-02-27T19:35:32Z",
+    "Published": "2013-02-27T19:35:32Z"
   }
 ]

--- a/scm/driver/github/testdata/webhooks/release.json.golden
+++ b/scm/driver/github/testdata/webhooks/release.json.golden
@@ -18,6 +18,16 @@
     "Created": "2019-05-15T15:19:25Z",
     "Updated": "2019-05-15T15:20:41Z"
   },
+  "Release": {
+    "ID": 17372790,
+    "Link": "https://github.com/Codertocat/Hello-World/releases/tag/0.0.1",
+    "Tag": "0.0.1",
+    "Commitish": "master",
+    "Draft": false,
+    "Prerelease": false,
+    "Created": "2019-05-15T15:19:25Z",
+    "Published": "2019-05-15T15:20:53Z"
+  },
   "Sender": {
     "ID": 21031067,
     "Login": "Codertocat",

--- a/scm/driver/github/webhook.go
+++ b/scm/driver/github/webhook.go
@@ -487,6 +487,7 @@ type (
 	releaseHook struct {
 		Action       string           `json:"action"`
 		Repository   repository       `json:"repository"`
+		Release      release          `json:"release"`
 		Sender       user             `json:"sender"`
 		Label        label            `json:"label"`
 		Installation *installationRef `json:"installation"`
@@ -903,6 +904,7 @@ func convertReleaseHook(dst *releaseHook) *scm.ReleaseHook {
 	return &scm.ReleaseHook{
 		Action:       convertAction(dst.Action),
 		Repo:         *convertRepository(&dst.Repository),
+		Release:      *convertRelease(&dst.Release),
 		Sender:       *convertUser(&dst.Sender),
 		Label:        convertLabel(dst.Label),
 		Installation: convertInstallationRef(dst.Installation),

--- a/scm/driver/gitlab/testdata/webhooks/release.json
+++ b/scm/driver/gitlab/testdata/webhooks/release.json
@@ -1,0 +1,70 @@
+{
+  "id": 1,
+  "created_at": "2020-11-02 12:55:12 UTC",
+  "description": "v1.0 has been released",
+  "name": "v1.1",
+  "released_at": "2020-11-02 12:55:12 UTC",
+  "tag": "v1.1",
+  "object_kind": "release",
+  "project": {
+    "id": 2,
+    "name": "release-webhook-example",
+    "description": "",
+    "web_url": "https://example.com/gitlab-org/release-webhook-example",
+    "avatar_url": null,
+    "git_ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+    "git_http_url": "https://example.com/gitlab-org/release-webhook-example.git",
+    "namespace": "Gitlab",
+    "visibility_level": 0,
+    "path_with_namespace": "gitlab-org/release-webhook-example",
+    "default_branch": "master",
+    "ci_config_path": null,
+    "homepage": "https://example.com/gitlab-org/release-webhook-example",
+    "url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+    "ssh_url": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+    "http_url": "https://example.com/gitlab-org/release-webhook-example.git"
+  },
+  "url": "https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1",
+  "action": "create",
+  "assets": {
+    "count": 5,
+    "links": [
+      {
+        "id": 1,
+        "external": true,
+        "link_type": "other",
+        "name": "Changelog",
+        "url": "https://example.net/changelog"
+      }
+    ],
+    "sources": [
+      {
+        "format": "zip",
+        "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.zip"
+      },
+      {
+        "format": "tar.gz",
+        "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.gz"
+      },
+      {
+        "format": "tar.bz2",
+        "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar.bz2"
+      },
+      {
+        "format": "tar",
+        "url": "https://example.com/gitlab-org/release-webhook-example/-/archive/v1.1/release-webhook-example-v1.1.tar"
+      }
+    ]
+  },
+  "commit": {
+    "id": "ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+    "message": "Release v1.1",
+    "title": "Release v1.1",
+    "timestamp": "2020-10-31T14:58:32+11:00",
+    "url": "https://example.com/gitlab-org/release-webhook-example/-/commit/ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+    "author": {
+      "name": "Example User",
+      "email": "user@example.com"
+    }
+  }
+}

--- a/scm/driver/gitlab/testdata/webhooks/release.json.golden
+++ b/scm/driver/gitlab/testdata/webhooks/release.json.golden
@@ -1,0 +1,27 @@
+{
+    "Action": "created",
+    "Release": {
+        "ID": 1,
+        "Title": "v1.1",
+        "Description": "v1.0 has been released",
+        "Link": "https://example.com/gitlab-org/release-webhook-example/-/releases/v1.1",
+        "Tag": "v1.1",
+        "Commitish": "ee0a3fb31ac16e11b9dbb596ad16d4af654d08f8",
+        "Created": "2020-11-02T12:55:12Z",
+        "Published": "2020-11-02T12:55:12Z"
+    },
+    "Repo": {
+        "ID": "2",
+        "Namespace": "gitlab-org",
+        "Name": "release-webhook-example",
+        "FullName": "gitlab-org/release-webhook-example",
+        "Perm": null,
+        "Branch": "master",
+        "Private": false,
+        "Clone": "https://example.com/gitlab-org/release-webhook-example.git",
+        "CloneSSH": "ssh://git@example.com/gitlab-org/release-webhook-example.git",
+        "Link": "https://example.com/gitlab-org/release-webhook-example",
+        "Created": "0001-01-01T00:00:00Z",
+        "Updated": "0001-01-01T00:00:00Z"
+    }
+}

--- a/scm/driver/gitlab/webhook_test.go
+++ b/scm/driver/gitlab/webhook_test.go
@@ -152,6 +152,13 @@ func TestWebhooks(t *testing.T) {
 				},
 			},
 		},
+		// release hooks
+		{
+			event:  "Release Hook",
+			before: "testdata/webhooks/release.json",
+			after:  "testdata/webhooks/release.json.golden",
+			obj:    new(scm.ReleaseHook),
+		},
 	}
 
 	for _, test := range tests {

--- a/scm/driver/gogs/release.go
+++ b/scm/driver/gogs/release.go
@@ -1,0 +1,33 @@
+package gogs
+
+import (
+	"time"
+
+	"github.com/jenkins-x/go-scm/scm"
+)
+
+type release struct {
+	ID          int       `json:"id"`
+	Title       string    `json:"name"`
+	Description string    `json:"body"`
+	Tag         string    `json:"tag_name"`
+	Commitish   string    `json:"target_commitish"`
+	Draft       bool      `json:"draft"`
+	Prerelease  bool      `json:"prerelease"`
+	Author      *user     `json:"author"`
+	Created     time.Time `json:"created_at"`
+}
+
+func convertRelease(from *release) *scm.Release {
+	return &scm.Release{
+		ID:          from.ID,
+		Title:       from.Title,
+		Description: from.Description,
+		Tag:         from.Tag,
+		Commitish:   from.Commitish,
+		Draft:       from.Draft,
+		Prerelease:  from.Prerelease,
+		Created:     from.Created,
+		Published:   from.Created,
+	}
+}

--- a/scm/driver/gogs/testdata/webhooks/release.json
+++ b/scm/driver/gogs/testdata/webhooks/release.json
@@ -1,0 +1,51 @@
+{
+  "release": {
+    "id": 1,
+    "name": "v1.0.0",
+    "body": "Description of the release",
+    "tag_name": "v1.0.0",
+    "target_commitish": "master",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2017-12-10T01:30:43Z"
+  },
+  "repository": {
+    "id": 61,
+    "owner": {
+      "id": 25,
+      "login": "gogits",
+      "full_name": "",
+      "email": "",
+      "avatar_url": "http://try.gogs.io/avatars/25",
+      "username": "gogits"
+    },
+    "name": "hello-world",
+    "full_name": "gogits/hello-world",
+    "description": "",
+    "private": true,
+    "fork": false,
+    "parent": null,
+    "empty": false,
+    "mirror": false,
+    "size": 24576,
+    "html_url": "http://try.gogs.io/gogits/hello-world",
+    "ssh_url": "git@localhost:gogits/hello-world.git",
+    "clone_url": "http://try.gogs.io/gogits/hello-world.git",
+    "website": "",
+    "stars_count": 0,
+    "forks_count": 0,
+    "watchers_count": 2,
+    "open_issues_count": 0,
+    "default_branch": "master",
+    "created_at": "2017-12-09T01:30:43Z",
+    "updated_at": "2017-12-09T01:33:08Z"
+  },
+  "sender": {
+    "id": 1,
+    "login": "unknwon",
+    "full_name": "",
+    "email": "noreply@gogs.io",
+    "avatar_url": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87",
+    "username": "unknwon"
+  }
+}

--- a/scm/driver/gogs/testdata/webhooks/release.json.golden
+++ b/scm/driver/gogs/testdata/webhooks/release.json.golden
@@ -1,0 +1,34 @@
+{
+  "Repo": {
+    "ID": "61",
+    "Namespace": "gogits",
+    "Name": "hello-world",
+    "FullName": "gogits/hello-world",
+    "Perm": {},
+    "Branch": "master",
+    "Private": true,
+    "Clone": "http://try.gogs.io/gogits/hello-world.git",
+    "CloneSSH": "git@localhost:gogits/hello-world.git",
+    "Link": "",
+    "Created": "0001-01-01T00:00:00Z",
+    "Updated": "0001-01-01T00:00:00Z"
+  },
+  "Release": {
+    "ID": 1,
+    "Title": "v1.0.0",
+    "Description": "Description of the release",
+    "Tag": "v1.0.0",
+    "Commitish": "master",
+    "Draft": false,
+    "Prerelease": false,
+    "Created": "2017-12-10T01:30:43Z",
+    "Published": "2017-12-10T01:30:43Z"
+  },
+  "Sender": {
+    "Login": "unknwon",
+    "Name": "",
+    "Email": "noreply@gogs.io",
+    "Avatar": "https://secure.gravatar.com/avatar/8c58a0be77ee441bb8f8595b7f1b4e87"
+  },
+  "Guid": "ee8d97b4-1479-43f1-9cac-fbbd1b80da55"
+}

--- a/scm/driver/gogs/webhook_test.go
+++ b/scm/driver/gogs/webhook_test.go
@@ -116,6 +116,14 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/pull_request_comment_created.json.golden",
 			obj:    new(scm.PullRequestCommentHook),
 		},
+		// release hooks
+		{
+			sig:    "9edf3260d727e29d906bdb10c8a099666a3df4f033084e244fd56ef8828c9bea",
+			event:  "release",
+			before: "testdata/webhooks/release.json",
+			after:  "testdata/webhooks/release.json.golden",
+			obj:    new(scm.ReleaseHook),
+		},
 	}
 
 	for _, test := range tests {

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -68,18 +68,6 @@ type (
 		DueDate     *time.Time
 	}
 
-	// Release the release
-	Release struct {
-		ID          int
-		Title       string
-		Description string
-		Link        string
-		Tag         string
-		Commitish   string
-		Draft       bool
-		Prerelease  bool
-	}
-
 	// PullRequestListOptions provides options for querying
 	// a list of repository merge requests.
 	PullRequestListOptions struct {

--- a/scm/release.go
+++ b/scm/release.go
@@ -2,9 +2,24 @@ package scm
 
 import (
 	"context"
+	"time"
 )
 
 type (
+	// Release the release
+	Release struct {
+		ID          int
+		Title       string
+		Description string
+		Link        string
+		Tag         string
+		Commitish   string
+		Draft       bool
+		Prerelease  bool
+		Created     time.Time
+		Published   time.Time
+	}
+
 	// ReleaseInput contains the information needed to create a release
 	ReleaseInput struct {
 		Title       string

--- a/scm/webhook.go
+++ b/scm/webhook.go
@@ -247,6 +247,7 @@ type (
 	ReleaseHook struct {
 		Action       Action
 		Repo         Repository
+		Release      Release
 		Sender       User
 		Label        Label
 		Installation *InstallationRef


### PR DESCRIPTION
the release webhook payload was missing... the release

implemented for: github, gitlab, gitea and gogs