### PR TITLE
feat: create hooks with release events

### DIFF
--- a/scm/driver/gitea/repo.go
+++ b/scm/driver/gitea/repo.go
@@ -308,6 +308,9 @@ func convertHookEvent(from scm.HookEvents) []string {
 	if from.Push {
 		events = append(events, "push")
 	}
+	if from.Release {
+		events = append(events, "release")
+	}
 	return events
 }
 

--- a/scm/driver/gitea/repo_test.go
+++ b/scm/driver/gitea/repo_test.go
@@ -261,6 +261,10 @@ func TestHookEvents(t *testing.T) {
 			out: []string{"pull_request_review"},
 		},
 		{
+			in:  scm.HookEvents{Release: true},
+			out: []string{"release"},
+		},
+		{
 			in: scm.HookEvents{
 				Branch:             true,
 				Issue:              true,
@@ -268,11 +272,12 @@ func TestHookEvents(t *testing.T) {
 				PullRequest:        true,
 				PullRequestComment: true,
 				Push:               true,
+				Release:            true,
 				Review:             true,
 				ReviewComment:      true,
 				Tag:                true,
 			},
-			out: []string{"pull_request", "pull_request_review", "pull_request_review_comment", "issues", "issue_comment", "create", "delete", "push"},
+			out: []string{"pull_request", "pull_request_review", "pull_request_review_comment", "issues", "issue_comment", "create", "delete", "push", "release"},
 		},
 	}
 	for _, test := range tests {

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -424,6 +424,9 @@ func convertHookEvents(from scm.HookEvents) []string {
 	if from.DeploymentStatus {
 		events = append(events, "deployment_status")
 	}
+	if from.Release {
+		events = append(events, "release")
+	}
 	return events
 }
 

--- a/scm/driver/github/repo_test.go
+++ b/scm/driver/github/repo_test.go
@@ -582,6 +582,10 @@ func TestHookEvents(t *testing.T) {
 			out: []string{"deployment_status"},
 		},
 		{
+			in:  scm.HookEvents{Release: true},
+			out: []string{"release"},
+		},
+		{
 			in: scm.HookEvents{
 				Branch:             true,
 				Deployment:         true,
@@ -591,10 +595,11 @@ func TestHookEvents(t *testing.T) {
 				PullRequest:        true,
 				PullRequestComment: true,
 				Push:               true,
+				Release:            true,
 				ReviewComment:      true,
 				Tag:                true,
 			},
-			out: []string{"push", "pull_request", "pull_request_review_comment", "issues", "issue_comment", "create", "delete", "deployment", "deployment_status"},
+			out: []string{"push", "pull_request", "pull_request_review_comment", "issues", "issue_comment", "create", "delete", "deployment", "deployment_status", "release"},
 		},
 	}
 	for i, test := range tests {

--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -381,6 +381,9 @@ func (s *repositoryService) CreateHook(ctx context.Context, repo string, input *
 	if input.Events.Tag || hasStarEvents {
 		params.Set("tag_push_events", "true")
 	}
+	if input.Events.Release || hasStarEvents {
+		params.Set("releases_events", "true")
+	}
 
 	path := fmt.Sprintf("api/v4/projects/%s/hooks?%s", encode(repo), params.Encode())
 	out := new(hook)

--- a/scm/driver/gogs/repo.go
+++ b/scm/driver/gogs/repo.go
@@ -246,5 +246,8 @@ func convertHookEvent(from scm.HookEvents) []string {
 	if from.Push {
 		events = append(events, "push")
 	}
+	if from.Release {
+		events = append(events, "release")
+	}
 	return events
 }

--- a/scm/driver/gogs/repo_test.go
+++ b/scm/driver/gogs/repo_test.go
@@ -235,6 +235,10 @@ func TestHookEvents(t *testing.T) {
 			out: []string{"pull_request"},
 		},
 		{
+			in:  scm.HookEvents{Release: true},
+			out: []string{"release"},
+		},
+		{
 			in: scm.HookEvents{
 				Branch:             true,
 				Issue:              true,
@@ -242,10 +246,11 @@ func TestHookEvents(t *testing.T) {
 				PullRequest:        true,
 				PullRequestComment: true,
 				Push:               true,
+				Release:            true,
 				ReviewComment:      true,
 				Tag:                true,
 			},
-			out: []string{"pull_request", "issues", "issue_comment", "create", "delete", "push"},
+			out: []string{"pull_request", "issues", "issue_comment", "create", "delete", "push", "release"},
 		},
 	}
 	for _, test := range tests {

--- a/scm/repo.go
+++ b/scm/repo.go
@@ -90,6 +90,7 @@ type (
 		PullRequest        bool
 		PullRequestComment bool
 		Push               bool
+		Release            bool
 		Review             bool
 		ReviewComment      bool
 		Tag                bool


### PR DESCRIPTION
add the ability to create webhooks for 'release' events

implemented for: github, gitlab, gitea, gogs