### PR TITLE
fix: bitbucket oauth flow fixed

### DIFF
--- a/scm/client.go
+++ b/scm/client.go
@@ -103,6 +103,8 @@ type (
 
 		// Username is the optional user name for the client
 		Username string
+		// useOAuth is a flag to set Bitbucket as an OAuth Consumer
+		UseOAuth bool
 
 		// Services used for communicating with the API.
 		Driver        Driver

--- a/scm/client.go
+++ b/scm/client.go
@@ -103,8 +103,6 @@ type (
 
 		// Username is the optional user name for the client
 		Username string
-		// useOAuth is a flag to set Bitbucket as an OAuth Consumer
-		UseOAuth bool
 
 		// Services used for communicating with the API.
 		Driver        Driver

--- a/scm/factory/factory.go
+++ b/scm/factory/factory.go
@@ -41,6 +41,13 @@ func SetUsername(username string) ClientOptionFunc {
 	}
 }
 
+// EnableBBOAuth sets useOAuth flag to true
+func EnableBBOAuth() ClientOptionFunc {
+	return func(client *scm.Client) {
+		client.UseOAuth = true
+	}
+}
+
 // NewClientWithBasicAuth creates a new client for a given driver, serverURL and basic auth
 func NewClientWithBasicAuth(driver, serverURL, user, password string, opts ...ClientOptionFunc) (*scm.Client, error) {
 	if driver == "" {
@@ -140,13 +147,12 @@ func NewClient(driver, serverURL, oauthToken string, opts ...ClientOptionFunc) (
 			if client.Username == "" {
 				return nil, errors.Errorf("no username supplied")
 			}
-			isOAuth := os.Getenv("BB_OAUTH")
-			if (isOAuth != "") {
+			if client.UseOAuth {
 				credentials := strings.SplitN(oauthToken, ":", 2)
 				config := clientcredentials.Config{
-					ClientID: credentials[0],
+					ClientID:     credentials[0],
 					ClientSecret: credentials[1],
-					TokenURL: "https://bitbucket.org/site/oauth2/access_token",
+					TokenURL:     "https://bitbucket.org/site/oauth2/access_token",
 				}
 				client.Client = config.Client(context.Background())
 				return client, nil

--- a/scm/factory/factory.go
+++ b/scm/factory/factory.go
@@ -192,10 +192,15 @@ func NewClientFromEnvironment() (*scm.Client, error) {
 		username = os.Getenv("GIT_USERNAME")
 	}
 
+	opts := []ClientOptionFunc{SetUsername(username)}
+	if os.Getenv("BB_OAUTH") != "" {
+		opts = append(opts, EnableBBOAuth())
+	}
+
 	if oauthToken == "" {
 		return nil, fmt.Errorf("No Git OAuth token specified for $GIT_TOKEN")
 	}
-	client, err := NewClient(driver, serverURL, oauthToken, SetUsername(username))
+	client, err := NewClient(driver, serverURL, oauthToken, opts...)
 	if driver == "" {
 		driver = client.Driver.String()
 	}

--- a/scm/factory/factory.go
+++ b/scm/factory/factory.go
@@ -142,20 +142,13 @@ func NewClient(driver, serverURL, oauthToken string, opts ...ClientOptionFunc) (
 			}
 			isOAuth := os.Getenv("BB_OAUTH")
 			if (isOAuth != "") {
+				credentials := strings.SplitN(oauthToken, ":", 2)
 				config := clientcredentials.Config{
-					ClientID: client.Username,
-					ClientSecret: oauthToken,
+					ClientID: credentials[0],
+					ClientSecret: credentials[1],
 					TokenURL: "https://bitbucket.org/site/oauth2/access_token",
 				}
-				token, err := config.Token(context.Background())
-				if err != nil {
-					return nil, errors.Errorf("Unable to obtain Access Token.")
-				}
-				client.Client = &http.Client{
-					Transport: &transport.BearerToken{
-						Token: token.AccessToken,
-					},
-				}
+				client.Client = config.Client(context.Background())
 				return client, nil
 			}
 			// BB App Password / PAT


### PR DESCRIPTION
BitBucket Cloud OAuth flow was boken for a number of reasons.

Now, with the use of an env variable, we can request an AccessToken
from BB, and then use that for Bearer authentication against BitBuckets
API.