### PR TITLE
fix: get gitlab projects/groups members api

### DIFF
--- a/scm/driver/gitlab/org.go
+++ b/scm/driver/gitlab/org.go
@@ -76,7 +76,7 @@ func (s *organizationService) ListOrgMembers(ctx context.Context, org string, op
 }
 
 func (s *organizationService) ListMemberUsers(ctx context.Context, org string, opts scm.ListOptions) ([]scm.User, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/members/all?%s", org, encodeListOptions(opts))
+	path := fmt.Sprintf("api/v4/groups/%s/members?%s", org, encodeListOptions(opts))
 	out := []*user{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertUserList(out), res, err

--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -221,7 +221,7 @@ func (s *repositoryService) FindUserPermission(ctx context.Context, repo string,
 		Page: 1,
 	}
 	for !firstRun || (resp != nil && opts.Page <= resp.Page.Last) {
-		path := fmt.Sprintf("api/v4/projects/%s/members/all?%s", encode(repo), encodeListOptions(opts))
+		path := fmt.Sprintf("api/v4/projects/%s/members?%s", encode(repo), encodeListOptions(opts))
 		out := []*member{}
 		resp, err = s.client.do(ctx, "GET", path, nil, &out)
 		if err != nil {
@@ -284,7 +284,7 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 }
 
 func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, ops scm.ListOptions) ([]scm.User, *scm.Response, error) {
-	path := fmt.Sprintf("api/v4/projects/%s/members/all?%s", encode(repo), encodeListOptions(ops))
+	path := fmt.Sprintf("api/v4/projects/%s/members?%s", encode(repo), encodeListOptions(ops))
 	out := []*user{}
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
 	return convertUserList(out), res, err

--- a/scm/driver/gitlab/repo_test.go
+++ b/scm/driver/gitlab/repo_test.go
@@ -250,7 +250,7 @@ func TestListContributor(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://gitlab.com").
-		Get("/api/v4/projects/diaspora/diaspora/members/all").
+		Get("/api/v4/projects/diaspora/diaspora/members").
 		Reply(200).
 		Type("application/json").
 		SetHeaders(mockHeaders).
@@ -559,7 +559,7 @@ func TestRepositoryFindUserPermission(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("https://gitlab.com").
-		Get("/api/v4/projects/diaspora/diaspora/members/all").
+		Get("/api/v4/projects/diaspora/diaspora/members").
 		Reply(200).
 		Type("application/json").
 		SetHeaders(mockHeaders).


### PR DESCRIPTION
Reference: [list-all-members-of-a-group-or-project](https://docs.gitlab.com/ee/api/members.html#list-all-members-of-a-group-or-project)