### PR TITLE
Fix Bitbucket IsCollaborator api

### DIFF
--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -124,7 +124,8 @@ func convertPRComment(from *prComment) *scm.Comment {
 		ID:   from.ID,
 		Body: from.Content.Raw,
 		Author: scm.User{
-			Login:  from.User.DisplayName,
+			Name:   from.User.DisplayName,
+			Login:  from.User.AccountID,
 			Avatar: from.User.Links.Avatar.Href,
 		},
 		Link:    from.Links.HTML.Href,

--- a/scm/driver/bitbucket/testdata/pr_create.json.golden
+++ b/scm/driver/bitbucket/testdata/pr_create.json.golden
@@ -54,7 +54,7 @@
   "MergeSha": "",
   "Author": {
     "ID": 0,
-    "Login": "",
+    "Login": "557058:8ad5a564-ff17-4b3f-8b89-67d523e02c90",
     "Name": "James Strachan",
     "Email": "",
     "Avatar": "https://secure.gravatar.com/avatar/64dbbbeb960d4014b28cd64d73340d94?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJS-3.png",

--- a/scm/driver/bitbucket/testdata/pulls.json.golden
+++ b/scm/driver/bitbucket/testdata/pulls.json.golden
@@ -56,7 +56,7 @@
     "MergeableState": "",
     "MergeSha": "",
     "Author": {
-      "Login": "",
+      "Login": "557058:8ad5a564-ff17-4b3f-8b89-67d523e02c90",
       "Name": "James Strachan",
       "Email": "",
       "Avatar": "https://secure.gravatar.com/avatar/64dbbbeb960d4014b28cd64d73340d94?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJS-3.png",
@@ -133,7 +133,7 @@
     "MergeableState": "",
     "MergeSha": "",
     "Author": {
-      "Login": "",
+      "Login": "557058:8ad5a564-ff17-4b3f-8b89-67d523e02c90",
       "Name": "James Strachan",
       "Email": "",
       "Avatar": "https://secure.gravatar.com/avatar/64dbbbeb960d4014b28cd64d73340d94?d=https%3A%2F%2Favatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FJS-3.png",

--- a/scm/driver/bitbucket/user.go
+++ b/scm/driver/bitbucket/user.go
@@ -49,6 +49,7 @@ func (s *userService) AcceptInvitation(context.Context, int64) (*scm.Response, e
 }
 
 type user struct {
+	AccountID    string `json:"account_id"`
 	Login        string `json:"username"`
 	Name         string `json:"nickname"`
 	EmailAddress string `json:"emailAddress"`
@@ -65,7 +66,7 @@ type user struct {
 }
 
 func (u *user) GetLogin() string {
-	answer := u.Login
+	answer := u.AccountID
 	return answer
 }
 

--- a/scm/driver/bitbucket/webhook.go
+++ b/scm/driver/bitbucket/webhook.go
@@ -545,14 +545,14 @@ func (s *webhookService) convertPushHook(src *pushHook) (*scm.PushHook, error) {
 			Message: change.New.Target.Message,
 			Link:    change.New.Target.Links.HTML.Href,
 			Author: scm.Signature{
-				Login:  change.New.Target.Author.User.Username,
+				Login:  validUser(change.New.Target.Author.User.AccountID, change.New.Target.Author.User.Username),
 				Email:  extractEmail(change.New.Target.Author.Raw),
 				Name:   change.New.Target.Author.User.DisplayName,
 				Avatar: change.New.Target.Author.User.Links.Avatar.Href,
 				Date:   change.New.Target.Date,
 			},
 			Committer: scm.Signature{
-				Login:  change.New.Target.Author.User.Username,
+				Login:  validUser(change.New.Target.Author.User.AccountID, change.New.Target.Author.User.Username),
 				Email:  extractEmail(change.New.Target.Author.Raw),
 				Name:   change.New.Target.Author.User.DisplayName,
 				Avatar: change.New.Target.Author.User.Links.Avatar.Href,
@@ -561,7 +561,7 @@ func (s *webhookService) convertPushHook(src *pushHook) (*scm.PushHook, error) {
 		},
 		Repo: repo,
 		Sender: scm.User{
-			Login:  src.Actor.Username,
+			Login:  validUser(src.Actor.AccountID, src.Actor.Username),
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},
@@ -606,7 +606,7 @@ func convertBranchCreateHook(src *pushHook) *scm.BranchHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
-			Login:  src.Actor.Username,
+			Login:  validUser(src.Actor.AccountID, src.Actor.Username),
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},
@@ -634,7 +634,7 @@ func convertBranchDeleteHook(src *pushHook) *scm.BranchHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
-			Login:  src.Actor.Username,
+			Login:  validUser(src.Actor.AccountID, src.Actor.Username),
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},
@@ -662,7 +662,7 @@ func convertTagCreateHook(src *pushHook) *scm.TagHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
-			Login:  src.Actor.Username,
+			Login:  validUser(src.Actor.AccountID, src.Actor.Username),
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},
@@ -690,11 +690,25 @@ func convertTagDeleteHook(src *pushHook) *scm.TagHook {
 			Link:      src.Repository.Links.HTML.Href,
 		},
 		Sender: scm.User{
-			Login:  src.Actor.Username,
+			Login:  validUser(src.Actor.AccountID, src.Actor.Username),
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},
 	}
+}
+
+// TODO, this is hack to support 2.0 API amendment.
+// username is unavailable in response since 2.0 release
+// this hack may not be needed since other sources are assuming 2.0 API version
+// return account Id in case user name is empty
+func validUser(acId string, userName string) string {
+	result := userName
+
+	if userName == "" {
+		result = acId
+	}
+
+	return result
 }
 
 //
@@ -729,7 +743,7 @@ func (s *webhookService) convertPullRequestHook(src *webhook) (*scm.PullRequestH
 			Closed: src.PullRequest.State != "OPEN",
 			Merged: src.PullRequest.State == "MERGED",
 			Author: scm.User{
-				Login:  src.PullRequest.Author.Username,
+				Login:  validUser(src.PullRequest.Author.AccountID, src.PullRequest.Author.Username),
 				Name:   src.PullRequest.Author.DisplayName,
 				Avatar: src.PullRequest.Author.Links.Avatar.Href,
 			},
@@ -738,7 +752,7 @@ func (s *webhookService) convertPullRequestHook(src *webhook) (*scm.PullRequestH
 		},
 		Repo: repo,
 		Sender: scm.User{
-			Login:  src.Actor.Username,
+			Login:  validUser(src.Actor.AccountID, src.Actor.Username),
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},
@@ -826,7 +840,7 @@ func (s *webhookService) convertPullRequestCommentHook(src *webhookPRComment) (*
 			Closed: src.PullRequest.State != "OPEN",
 			Merged: src.PullRequest.State == "MERGED",
 			Author: scm.User{
-				Login:  src.PullRequest.Author.Username,
+				Login:  validUser(src.PullRequest.Author.AccountID, src.PullRequest.Author.Username),
 				Name:   src.PullRequest.Author.DisplayName,
 				Avatar: src.PullRequest.Author.Links.Avatar.Href,
 			},
@@ -836,7 +850,7 @@ func (s *webhookService) convertPullRequestCommentHook(src *webhookPRComment) (*
 		},
 		Repo: prRepo,
 		Sender: scm.User{
-			Login:  src.Actor.Username,
+			Login:  validUser(src.Actor.AccountID, src.Actor.Username),
 			Name:   src.Actor.DisplayName,
 			Avatar: src.Actor.Links.Avatar.Href,
 		},


### PR DESCRIPTION
Fix bitbucket.IsCollaborator and streamline initialisation of Login attribute value
* check repo permission for a user using account id instead of username since bitbucket clould 2.0 API has stopped using username in the API.
* initialise Login attribute with AccountId since  bitbucket clould 2.0 API responses do not include username in the result