### PR TITLE
fix: add omitempty

### DIFF
--- a/scm/driver/github/review.go
+++ b/scm/driver/github/review.go
@@ -113,10 +113,10 @@ type reviewComment struct {
 }
 
 type reviewInput struct {
-	Body     string                `json:"body"`
-	CommitID string                `json:"commit_id"`
-	Event    string                `json:"event"`
-	Comments []*reviewCommentInput `json:"comments"`
+	Body     string                `json:"body,omitempty"`
+	CommitID string                `json:"commit_id,omitempty"`
+	Event    string                `json:"event,omitempty"`
+	Comments []*reviewCommentInput `json:"comments,omitempty"`
 }
 
 type reviewCommentInput struct {


### PR DESCRIPTION
The API doesn't like it when fields like `comments` or `commit_id` are there but empty or null. If they're not set, it's best to omit them entirely.