### PR TITLE
fix: error fetching sha for branch name with slash in it

### DIFF
--- a/scm/driver/bitbucket/testdata/webhooks/pr_created_slashbranch.json
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_created_slashbranch.json
@@ -1,0 +1,191 @@
+{
+  "pullrequest": {
+    "type": "pullrequest",
+    "description": "made some changes",
+    "links": {
+      "decline": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/decline"
+      },
+      "commits": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/commits"
+      },
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1"
+      },
+      "comments": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/comments"
+      },
+      "merge": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/merge"
+      },
+      "html": {
+        "href": "https://bitbucket.org/brydzewski/foo/pull-requests/1"
+      },
+      "activity": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/activity"
+      },
+      "diff": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/diff"
+      },
+      "approve": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/approve"
+      },
+      "statuses": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/pullrequests/1/statuses"
+      }
+    },
+    "title": "Awesome new feature",
+    "close_source_branch": false,
+    "reviewers": [],
+    "id": 1,
+    "destination": {
+      "commit": {
+        "hash": "7d1a175411ef",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/commit/7d1a175411ef"
+          }
+        }
+      },
+      "branch": {
+        "name": "master"
+      },
+      "repository": {
+        "full_name": "brydzewski/foo",
+        "type": "repository",
+        "name": "foo",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo"
+          },
+          "html": {
+            "href": "https://bitbucket.org/brydzewski/foo"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7Bbc771cbf-829e-4c4b-b71f-a0eb3ac2b860%7D?ts=default"
+          }
+        },
+        "uuid": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}"
+      }
+    },
+    "comment_count": 0,
+    "summary": {
+      "raw": "made some changes",
+      "markup": "markdown",
+      "html": "<p>made some changes</p>",
+      "type": "rendered"
+    },
+    "source": {
+      "commit": {
+        "hash": "507a576e59b3",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo/commit/507a576e59b3"
+          }
+        }
+      },
+      "branch": {
+        "name": "feature/develop"
+      },
+      "repository": {
+        "full_name": "brydzewski/foo",
+        "type": "repository",
+        "name": "foo",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo"
+          },
+          "html": {
+            "href": "https://bitbucket.org/brydzewski/foo"
+          },
+          "avatar": {
+            "href": "https://bytebucket.org/ravatar/%7Bbc771cbf-829e-4c4b-b71f-a0eb3ac2b860%7D?ts=default"
+          }
+        },
+        "uuid": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}"
+      }
+    },
+    "state": "OPEN",
+    "author": {
+      "username": "brydzewski",
+      "display_name": "Brad Rydzewski",
+      "account_id": "557058:2a6349dc-4346-4805-bd84-3abdd0812d17",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/brydzewski"
+        },
+        "html": {
+          "href": "https://bitbucket.org/brydzewski/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/brydzewski/avatar/32/"
+        }
+      },
+      "type": "user",
+      "uuid": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}"
+    },
+    "created_on": "2018-07-02T21:51:39.492248+00:00",
+    "participants": [],
+    "reason": "",
+    "updated_on": "2018-07-02T21:51:39.532546+00:00",
+    "merge_commit": null,
+    "closed_by": null,
+    "task_count": 0
+  },
+  "actor": {
+    "username": "brydzewski",
+    "display_name": "Brad Rydzewski",
+    "account_id": "557058:2a6349dc-4346-4805-bd84-3abdd0812d17",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/users/brydzewski"
+      },
+      "html": {
+        "href": "https://bitbucket.org/brydzewski/"
+      },
+      "avatar": {
+        "href": "https://bitbucket.org/account/brydzewski/avatar/32/"
+      }
+    },
+    "type": "user",
+    "uuid": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}"
+  },
+  "repository": {
+    "scm": "git",
+    "website": "",
+    "name": "foo",
+    "links": {
+      "self": {
+        "href": "https://api.bitbucket.org/2.0/repositories/brydzewski/foo"
+      },
+      "html": {
+        "href": "https://bitbucket.org/brydzewski/foo"
+      },
+      "avatar": {
+        "href": "https://bytebucket.org/ravatar/%7Bbc771cbf-829e-4c4b-b71f-a0eb3ac2b860%7D?ts=default"
+      }
+    },
+    "full_name": "brydzewski/foo",
+    "owner": {
+      "username": "brydzewski",
+      "display_name": "Brad Rydzewski",
+      "account_id": "557058:2a6349dc-4346-4805-bd84-3abdd0812d17",
+      "links": {
+        "self": {
+          "href": "https://api.bitbucket.org/2.0/users/brydzewski"
+        },
+        "html": {
+          "href": "https://bitbucket.org/brydzewski/"
+        },
+        "avatar": {
+          "href": "https://bitbucket.org/account/brydzewski/avatar/32/"
+        }
+      },
+      "type": "user",
+      "uuid": "{87bb15eb-47c1-49b3-9f16-ca824a2979a4}"
+    },
+    "type": "repository",
+    "is_private": true,
+    "uuid": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}"
+  }
+}

--- a/scm/driver/bitbucket/testdata/webhooks/pr_created_slashbranch.json.golden
+++ b/scm/driver/bitbucket/testdata/webhooks/pr_created_slashbranch.json.golden
@@ -1,0 +1,140 @@
+{
+  "Action": "opened",
+  "Repo": {
+    "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+    "Namespace": "brydzewski",
+    "Name": "foo",
+    "FullName": "brydzewski/foo",
+    "Perm": null,
+    "Branch": "",
+    "Private": true,
+    "Clone": "https://bitbucket.org/brydzewski/foo.git",
+    "CloneSSH": "git@bitbucket.org:brydzewski/foo.git",
+    "Link": "https://bitbucket.org/brydzewski/foo",
+    "Created": "0001-01-01T00:00:00Z",
+    "Updated": "0001-01-01T00:00:00Z"
+  },
+  "Label": {
+    "ID": 0,
+    "URL": "",
+    "Name": "",
+    "Description": "",
+    "Color": ""
+  },
+  "PullRequest": {
+    "Number": 1,
+    "Title": "Awesome new feature",
+    "Body": "made some changes",
+    "Labels": null,
+    "Sha": "507a576e59b3",
+    "Ref": "refs/pull-requests/1/from",
+    "Source": "feature/develop",
+    "Target": "master",
+    "Base": {
+      "Ref": "master",
+      "Sha": "",
+      "Repo": {
+        "ID": "{bc771cbf-829e-4c4b-b71f-a0eb3ac2b860}",
+        "Namespace": "brydzewski",
+        "Name": "foo",
+        "FullName": "brydzewski/foo",
+        "Perm": null,
+        "Branch": "",
+        "Private": true,
+        "Clone": "https://bitbucket.org/brydzewski/foo.git",
+        "CloneSSH": "git@bitbucket.org:brydzewski/foo.git",
+        "Link": "https://bitbucket.org/brydzewski/foo",
+        "Created": "0001-01-01T00:00:00Z",
+        "Updated": "0001-01-01T00:00:00Z"
+      }
+    },
+    "Head": {
+      "Ref": "feature/develop",
+      "Sha": "",
+      "Repo": {
+        "ID": "",
+        "Namespace": "",
+        "Name": "",
+        "FullName": "",
+        "Perm": null,
+        "Branch": "",
+        "Private": false,
+        "Clone": "",
+        "CloneSSH": "",
+        "Link": "",
+        "Created": "0001-01-01T00:00:00Z",
+        "Updated": "0001-01-01T00:00:00Z"
+      }
+    },
+    "Fork": "brydzewski/foo",
+    "State": "",
+    "Closed": false,
+    "Draft": false,
+    "Merged": false,
+    "Mergeable": false,
+    "Rebaseable": false,
+    "MergeableState": "",
+    "MergeSha": "",
+    "Author": {
+      "ID": 0,
+      "Login": "brydzewski",
+      "Name": "Brad Rydzewski",
+      "Email": "",
+      "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/",
+      "Link": "",
+      "Created": "0001-01-01T00:00:00Z",
+      "Updated": "0001-01-01T00:00:00Z"
+    },
+    "Assignees": null,
+    "Reviewers": null,
+    "Milestone": {
+      "Number": 0,
+      "ID": 0,
+      "Title": "",
+      "Description": "",
+      "Link": "",
+      "State": "",
+      "DueDate": null
+    },
+    "Created": "2018-07-02T21:51:39.492248Z",
+    "Updated": "2018-07-02T21:51:39.532546Z",
+    "Link": "https://bitbucket.org/brydzewski/foo/pull-requests/1",
+    "DiffLink": ""
+  },
+  "Sender": {
+    "ID": 0,
+    "Login": "brydzewski",
+    "Name": "Brad Rydzewski",
+    "Email": "",
+    "Avatar": "https://bitbucket.org/account/brydzewski/avatar/32/",
+    "Link": "",
+    "Created": "0001-01-01T00:00:00Z",
+    "Updated": "0001-01-01T00:00:00Z"
+  },
+  "Changes": {
+    "Base": {
+      "Ref": {
+        "From": ""
+      },
+      "Sha": {
+        "From": ""
+      },
+      "Repo": {
+        "ID": "",
+        "Namespace": "",
+        "Name": "",
+        "FullName": "",
+        "Perm": null,
+        "Branch": "",
+        "Private": false,
+        "Clone": "",
+        "CloneSSH": "",
+        "Link": "",
+        "Created": "0001-01-01T00:00:00Z",
+        "Updated": "0001-01-01T00:00:00Z"
+      }
+    }
+  },
+  "GUID": "",
+  "Installation": null
+}

--- a/scm/driver/bitbucket/webhook_test.go
+++ b/scm/driver/bitbucket/webhook_test.go
@@ -92,6 +92,14 @@ func TestWebhooks(t *testing.T) {
 			after:  "testdata/webhooks/pr_created.json.golden",
 			obj:    new(scm.PullRequestHook),
 		},
+		// pull request created, having branch name of pattern foo/bar
+		{
+			sig:    "71295b197fa25f4356d2fb9965df3f2379d903d7",
+			event:  "pullrequest:created",
+			before: "testdata/webhooks/pr_created_slashbranch.json",
+			after:  "testdata/webhooks/pr_created_slashbranch.json.golden",
+			obj:    new(scm.PullRequestHook),
+		},
 		// pull request updated
 		{
 			sig:    "71295b197fa25f4356d2fb9965df3f2379d903d7",


### PR DESCRIPTION
Fetching Sha of a branch (ref) with "/" in the name (e.g. foo/bar) returned "bar" incorrectly instead of its sha in case of BBC.
This caused the pipeline execution to fail.