### PR TITLE
gitlab: AddCollaborator tell when user is a member

### DIFF
--- a/scm/driver/gitlab/repo.go
+++ b/scm/driver/gitlab/repo.go
@@ -253,10 +253,15 @@ func (s *repositoryService) AddCollaborator(ctx context.Context, repo, username,
 		AccessLevel: stringToAccessLevel(permission),
 	}
 	res, err := s.client.do(ctx, "POST", path, in, &out)
+	if res.Status == 409 {
+		// GitLab returns 409 Conflict and message "Member already exists"
+		return false, true, res, err
+	}
 	if err != nil {
 		return false, false, res, err
 	}
-	return true, false, res, nil
+	// Return that user has become a member already (no invite/accept in GitLab)
+	return true, true, res, nil
 }
 
 func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user string) (bool, *scm.Response, error) {


### PR DESCRIPTION
Fixing AddCollaborator to tell when a user is already a member:
- response 409 Conflict signals user having already been a member
GitLab doesn't implement the invite/accept workflow:
- successfully adding a member also reports it as being a member

This is to prevent client code continuing with the invite/accept workflow after calling AddCollaborator.
E.g. https://github.com/jenkins-x-plugins/jx-project/pull/454