### PR TITLE
feat: add an option to enable GitHub discussion for a release

### DIFF
--- a/scm/driver/github/release.go
+++ b/scm/driver/github/release.go
@@ -26,12 +26,14 @@ type release struct {
 }
 
 type releaseInput struct {
-	Title       string `json:"name"`
-	Description string `json:"body"`
-	Tag         string `json:"tag_name"`
-	Commitish   string `json:"target_commitish"`
-	Draft       bool   `json:"draft"`
-	Prerelease  bool   `json:"prerelease"`
+	Title                  string `json:"name"`
+	Description            string `json:"body"`
+	Tag                    string `json:"tag_name"`
+	Commitish              string `json:"target_commitish"`
+	Draft                  bool   `json:"draft"`
+	Prerelease             bool   `json:"prerelease"`
+	DiscussionCategoryName string `json:"discussion_category_name,omitempty"`
+	GenerateReleaseNotes   bool   `json:"generate_release_notes,omitempty"`
 }
 
 func (s *releaseService) Find(ctx context.Context, repo string, id int) (*scm.Release, *scm.Response, error) {
@@ -58,12 +60,14 @@ func (s *releaseService) List(ctx context.Context, repo string, opts scm.Release
 func (s *releaseService) Create(ctx context.Context, repo string, input *scm.ReleaseInput) (*scm.Release, *scm.Response, error) {
 	path := fmt.Sprintf("repos/%s/releases", repo)
 	in := &releaseInput{
-		Title:       input.Title,
-		Commitish:   input.Commitish,
-		Description: input.Description,
-		Draft:       input.Draft,
-		Prerelease:  input.Prerelease,
-		Tag:         input.Tag,
+		Title:                  input.Title,
+		Commitish:              input.Commitish,
+		Description:            input.Description,
+		Draft:                  input.Draft,
+		Prerelease:             input.Prerelease,
+		Tag:                    input.Tag,
+		DiscussionCategoryName: input.DiscussionCategoryName,
+		GenerateReleaseNotes:   input.GenerateReleaseNotes,
 	}
 	out := new(release)
 	res, err := s.client.do(ctx, "POST", path, in, out)

--- a/scm/driver/github/release_test.go
+++ b/scm/driver/github/release_test.go
@@ -98,9 +98,10 @@ func TestReleaseCreate(t *testing.T) {
 
 	client := NewDefault()
 	input := &scm.ReleaseInput{
-		Title:       "v1.0",
-		Description: "Tracking release for version 1.0",
-		Tag:         "v1.0",
+		Title:                  "v1.0",
+		Description:            "Tracking release for version 1.0",
+		Tag:                    "v1.0",
+		DiscussionCategoryName: "general",
 	}
 
 	got, res, err := client.Releases.Create(context.Background(), "octocat/hello-world", input)

--- a/scm/driver/github/testdata/release.json
+++ b/scm/driver/github/testdata/release.json
@@ -15,6 +15,7 @@
   "prerelease": false,
   "created_at": "2013-02-27T19:35:32Z",
   "published_at": "2013-02-27T19:35:32Z",
+  "discussion_url": "https://github.com/octocat/Hello-World/discussions/9",
   "author": {
     "login": "octocat",
     "id": 1,

--- a/scm/release.go
+++ b/scm/release.go
@@ -22,12 +22,14 @@ type (
 
 	// ReleaseInput contains the information needed to create a release
 	ReleaseInput struct {
-		Title       string
-		Description string
-		Tag         string
-		Commitish   string
-		Draft       bool
-		Prerelease  bool
+		Title                  string
+		Description            string
+		Tag                    string
+		Commitish              string
+		Draft                  bool
+		Prerelease             bool
+		DiscussionCategoryName string
+		GenerateReleaseNotes   bool
 	}
 
 	// ReleaseListOptions provides options for querying a list of repository releases.


### PR DESCRIPTION
I'm not sure if this is appropriate to add a GitHub-specific option into the SCM struct. Please let me know if you have a better idea.