### PR TITLE
fix: add Sort option

### DIFF
--- a/scm/client.go
+++ b/scm/client.go
@@ -82,6 +82,7 @@ type (
 		Size int
 		From string
 		To   string
+		Sort string
 	}
 
 	// GraphQLService the API to performing GraphQL queries

--- a/scm/driver/gitlab/util.go
+++ b/scm/driver/gitlab/util.go
@@ -30,6 +30,9 @@ func encodeListOptions(opts *scm.ListOptions) string {
 	if opts.To != "" {
 		params.Set("to", opts.To)
 	}
+	if opts.Sort != "" {
+		params.Set("sort", opts.Sort)
+	}
 	return params.Encode()
 }
 

--- a/scm/driver/gitlab/util_test.go
+++ b/scm/driver/gitlab/util_test.go
@@ -14,8 +14,9 @@ func Test_encodeListOptions(t *testing.T) {
 	opts := scm.ListOptions{
 		Page: 10,
 		Size: 30,
+		Sort: "asc",
 	}
-	want := "page=10&per_page=30"
+	want := "page=10&per_page=30&sort=asc"
 	got := encodeListOptions(&opts)
 	if got != want {
 		t.Errorf("Want encoded list options %q, got %q", want, got)


### PR DESCRIPTION
Fix the order of getting comments in gitlab.
In order to correctly obtain the variables in PR。
After the new version is released, I will create a new PR on https://github.com/jenkins-x-plugins/jx-gitops。