### PR TITLE
fix: flanky force_remove_source_branch type

### DIFF
--- a/scm/driver/gitlab/testdata/webhooks/pull_request_comment_create.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_comment_create.json
@@ -69,7 +69,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": false
+      "force_remove_source_branch": "0"
     },
     "merge_status": "can_be_merged",
     "merge_user_id": null,

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_edited.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_edited.json
@@ -37,7 +37,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": false
+      "force_remove_source_branch": "0"
     },
     "merge_status": "unchecked",
     "merge_user_id": null,

--- a/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json
+++ b/scm/driver/gitlab/testdata/webhooks/pull_request_reopen.json
@@ -37,7 +37,7 @@
     "merge_commit_sha": null,
     "merge_error": null,
     "merge_params": {
-      "force_remove_source_branch": false
+      "force_remove_source_branch": "0"
     },
     "merge_status": "can_be_merged",
     "merge_user_id": null,

--- a/scm/driver/gitlab/webhook.go
+++ b/scm/driver/gitlab/webhook.go
@@ -613,7 +613,7 @@ type (
 			MergeCommitSha string      `json:"merge_commit_sha"`
 			MergeError     interface{} `json:"merge_error"`
 			MergeParams    struct {
-				ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
+				ForceRemoveSourceBranch interface{} `json:"force_remove_source_branch"`
 			} `json:"merge_params"`
 			MergeStatus               string      `json:"merge_status"`
 			MergeUserID               interface{} `json:"merge_user_id"`
@@ -698,7 +698,7 @@ type (
 			MergeCommitSha string      `json:"merge_commit_sha"`
 			MergeError     interface{} `json:"merge_error"`
 			MergeParams    struct {
-				ForceRemoveSourceBranch bool `json:"force_remove_source_branch"`
+				ForceRemoveSourceBranch interface{} `json:"force_remove_source_branch"`
 			} `json:"merge_params"`
 			MergeStatus               string      `json:"merge_status"`
 			MergeUserID               interface{} `json:"merge_user_id"`


### PR DESCRIPTION
Gitlab MergeRequestHook have unstable json type for this property. https://gitlab.com/gitlab-org/gitlab/-/issues/15647

closes jenkins-x/go-scm#300