### PR TITLE
feat: Improvements on fake

### DIFF
--- a/scm/driver/fake/pr.go
+++ b/scm/driver/fake/pr.go
@@ -119,9 +119,10 @@ func filterPullRequests(requests []*scm.PullRequest, opts *scm.PullRequestListOp
 		filteredPullRequests = newFilteredPullRequests
 	}
 
-	if len(opts.Labels) > 0 {
-		panic("implement me")
-	}
+	// Filtering on labels is not implemented in all real providers either...
+	// if len(opts.Labels) > 0 {
+	// 	panic("implement me")
+	// }
 
 	returnRequests := []*scm.PullRequest{}
 
@@ -357,6 +358,8 @@ func (s *pullService) Create(_ context.Context, fullName string, input *scm.Pull
 				FullName:  fullName,
 			},
 		},
+		Source: input.Head,
+		Link:   fmt.Sprintf("https://api.fake.com/pull/%d", f.PullRequestID),
 		Head: scm.PullRequestBranch{
 			Ref: input.Head,
 		},


### PR DESCRIPTION
Since filtering on labels is lacing on other providers I don't see that the fake should fail on that. A couple of more fields to be able to create tests for reuse of pull requests.

This is needed to make the tests in jenkins-x-plugins/jx-promote#412 work