### PR TITLE
Downgrade k8s.io/apimachinery to v0.26.3 (latest)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/stretchr/testify v1.8.2
 	golang.org/x/oauth2 v0.6.0
 	gopkg.in/h2non/gock.v1 v1.1.2
-	k8s.io/apimachinery v0.27.0-beta.0
+	k8s.io/apimachinery v0.26.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -186,6 +186,8 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.26.3 h1:dQx6PNETJ7nODU3XPtrwkfuubs6w7sX0M8n61zHIV/k=
+k8s.io/apimachinery v0.26.3/go.mod h1:ats7nN1LExKHvJ9TmwootT00Yz05MuYqPXEXaVeOy5I=
 k8s.io/apimachinery v0.27.0-beta.0 h1:oaNAx4OA7nrM/s6RGUx81PleoVXwwmhhPligkvP8KmE=
 k8s.io/apimachinery v0.27.0-beta.0/go.mod h1:5ikh59fK3AJ287GUvpUsryoMFtH9zj/ARfWCo3AyXTM=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=


### PR DESCRIPTION
A [previous dependabot change](https://github.com/jenkins-x/go-scm/pull/378) bumped this to a beta release candidate. This downgrades the depencency to the latest released version - v0.26.3.