### PR TITLE
fix login field value missing on bitbucket cloud

### DIFF
--- a/scm/driver/bitbucket/repo_test.go
+++ b/scm/driver/bitbucket/repo_test.go
@@ -65,6 +65,35 @@ func TestRepositoryFind_NotFound(t *testing.T) {
 	}
 }
 
+func TestListCollaborators(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.bitbucket.org").
+		Get("/2.0/workspaces/example/permissions/repositories/golang-http").
+		Reply(200).
+		Type("application/json").
+		File("testdata/repo-permision.json")
+
+	opt := &scm.ListOptions{}
+	client, _ := New("https://api.bitbucket.org")
+	got, _, err := client.Repositories.ListCollaborators(context.Background(), "example/golang-http", opt)
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := []scm.User{}
+	raw, _ := os.ReadFile("testdata/repo-permision.json.golden")
+	err = json.Unmarshal(raw, &want)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
 func TestRepositoryPerms(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/bitbucket/testdata/repo-permision.json
+++ b/scm/driver/bitbucket/testdata/repo-permision.json
@@ -1,0 +1,46 @@
+{
+    "values": [
+        {
+            "repository": {
+                "type": "repository",
+                "full_name": "example\/golang-http",
+                "links": {
+                    "self": {
+                        "href": "https:\/\/api.bitbucket.org\/2.0\/repositories\/example\/golang-http"
+                    },
+                    "html": {
+                        "href": "https:\/\/bitbucket.org\/example\/golang-http"
+                    },
+                    "avatar": {
+                        "href": "https:\/\/bytebucket.org\/ravatar\/%7Bb12c6309-ae42-4a66-8a9d-3a51433b4619%7D?ts=default"
+                    }
+                },
+                "name": "golang-http",
+                "uuid": "{b12c6309-ae42-4a66-8a9d-3a51433b4619}"
+            },
+            "type": "repository_permission",
+            "permission": "admin",
+            "user": {
+                "display_name": "John Doe",
+                "links": {
+                    "self": {
+                        "href": "https:\/\/api.bitbucket.org\/2.0\/users\/%7B4309d6fe-50d1-4b82-ac24-c08b7876bf30%7D"
+                    },
+                    "avatar": {
+                        "href": "https:\/\/avatar-management--avatars.us-west-2.prod.public.atl-paas.net\/5c9078461b780c2c5d7bac4c\/af6a67fb-5050-f425-9504-dc7e279e3e20\/128"
+                    },
+                    "html": {
+                        "href": "https:\/\/bitbucket.org\/%7B4309d6fe-50d1-4b82-ac24-c08b7876bf30%7D\/"
+                    }
+                },
+                "type": "user",
+                "uuid": "{4309d6fe-50d1-4b82-ac24-c08b7876bf30}",
+                "account_id": "5c9078461b780c2c5d7bac4c",
+                "nickname": "johndoe"
+            }
+        }
+    ],
+    "pagelen": 10,
+    "size": 1,
+    "page": 1
+}

--- a/scm/driver/bitbucket/testdata/repo-permision.json.golden
+++ b/scm/driver/bitbucket/testdata/repo-permision.json.golden
@@ -1,0 +1,8 @@
+[
+    {
+        "Login": "5c9078461b780c2c5d7bac4c",
+        "Name": "johndoe",
+        "Avatar": "https://bitbucket.org/account/5c9078461b780c2c5d7bac4c/avatar/32/",
+        "IsAdmin": false
+    }
+]

--- a/scm/driver/bitbucket/user.go
+++ b/scm/driver/bitbucket/user.go
@@ -79,9 +79,13 @@ func convertUser(from *user) *scm.User {
 	if name == "" {
 		name = from.DisplayName
 	}
+	login := from.Login
+	if login == "" {
+		login = from.AccountID
+	}
 	return &scm.User{
 		Avatar: fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32/", from.Login),
-		Login:  from.Login,
+		Login:  login,
 		Name:   name,
 	}
 }

--- a/scm/driver/bitbucket/user.go
+++ b/scm/driver/bitbucket/user.go
@@ -84,7 +84,7 @@ func convertUser(from *user) *scm.User {
 		login = from.AccountID
 	}
 	return &scm.User{
-		Avatar: fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32/", from.Login),
+		Avatar: fmt.Sprintf("https://bitbucket.org/account/%s/avatar/32/", login),
 		Login:  login,
 		Name:   name,
 	}


### PR DESCRIPTION
Since Bitbucket has removed the username field, the 'login' field need to be mapped with the user ID instead. Prior to this change, calling ListCollaborators would return:

```
{
    Login: "",
    Name:  "johndoe",
    Avatar: "https://bitbucket.org/account//avatar/32/"
}
```

After change:

```
 {
    Login: "5c9078461b780c2c5d7bac4c",
    Name:  "johndoe",
    Avatar: "https://bitbucket.org/account/5c9078461b780c2c5d7bac4c/avatar/32/"
 }
```

this causes all approvers being filtered and return empty owner result. see:

https://github.com/jenkins-x/lighthouse/blob/main/pkg/repoowners/repoowners.go#L293