### PR TITLE
Bump version of golang used for testing

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: build-make-linux
-      uses: docker://golang:1.18.4
+      uses: docker://golang:1.20.14
       with:
         args: -c "make check test"
         entrypoint: /bin/sh


### PR DESCRIPTION
Testing (running `go test ./...`) with go 1.18 fails with message
```
# github.com/go-git/go-git/v5/utils/trace
../../../go/pkg/mod/github.com/go-git/go-git/v5@v5.11.0/utils/trace/trace.go:15:17: undefined: atomic.Int32
note: module requires Go 1.19
```

Testing with go 1.21 or 1.22 fails with the message:
```
go: updates to go.mod needed; to update it:
	go mod tidy
```

Running `go mod tidy -go=1.19` yields:
```
go: k8s.io/apimachinery@v0.29.0 requires go@1.21, but 1.19 is requested
```

Running `go mod tidy` without specifying the version bumps the go version and go toolchain version. Running `make lint` after this causes a panic.

This PR simply bumps the go version for running tests to 1.20 to enable unrelated changes to be merged.