### PR TITLE
support Gitlab Draft mode field

### DIFF
--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -307,6 +307,7 @@ type pr struct {
 	Labels          []*string `json:"labels"`
 	Link            string    `json:"web_url"`
 	WIP             bool      `json:"work_in_progress"`
+	Draft           bool      `json:"draft"`
 	Author          user      `json:"author"`
 	MergeStatus     string    `json:"merge_status"`
 	SourceBranch    string    `json:"source_branch"`
@@ -411,7 +412,7 @@ func (s *pullService) convertPullRequest(ctx context.Context, from *pr) (*scm.Pu
 		Source:         from.SourceBranch,
 		Target:         from.TargetBranch,
 		Link:           from.Link,
-		Draft:          from.WIP,
+		Draft:          from.WIP || from.Draft,
 		Closed:         from.State != "opened",
 		Merged:         from.State == "merged",
 		Mergeable:      scm.ToMergeableState(from.MergeStatus) == scm.MergeableStateMergeable,


### PR DESCRIPTION
Gitlab has both WIP and Draft fields. Draft MRs should be observable work-in-porgress