### PR TITLE
fix: add github api value for conflict

### DIFF
--- a/scm/driver/github/testdata/webhooks/pr_closed.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_closed.json.golden
@@ -72,6 +72,7 @@
     "State": "closed",
     "Closed": true,
     "Merged": false,
+    "MergeableState": "conflicting",
     "Author": {
       "ID": 817538,
       "Login": "bradrydzewski",

--- a/scm/driver/github/testdata/webhooks/pr_edited.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_edited.json.golden
@@ -72,6 +72,7 @@
     "State": "open",
     "Closed": false,
     "Merged": false,
+    "MergeableState": "conflicting",
     "Author": {
       "ID": 817538,
       "Login": "bradrydzewski",

--- a/scm/driver/github/testdata/webhooks/pr_labeled.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_labeled.json.golden
@@ -84,6 +84,7 @@
     "State": "open",
     "Closed": false,
     "Merged": false,
+    "MergeableState": "conflicting",
     "Author": {
       "ID": 817538,
       "Login": "bradrydzewski",

--- a/scm/driver/github/testdata/webhooks/pr_unlabeled.json.golden
+++ b/scm/driver/github/testdata/webhooks/pr_unlabeled.json.golden
@@ -77,6 +77,7 @@
     "State": "open",
     "Closed": false,
     "Merged": false,
+    "MergeableState": "conflicting",
     "Author": {
       "ID": 817538,
       "Login": "bradrydzewski",

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -215,7 +215,7 @@ func ToMergeableState(text string) MergeableState {
 	switch strings.ToLower(text) {
 	case "clean", "mergeable", "can_be_merged":
 		return MergeableStateMergeable
-	case "conflict", "conflicting", "cannot_be_merged":
+	case "dirty", "conflict", "conflicting", "cannot_be_merged":
 		return MergeableStateConflicting
 	default:
 		return MergeableStateUnknown


### PR DESCRIPTION
This method is used to in (among others) the code for GitHub when interpreting the value of `mergeable_state` as returned by the rest API. But it seems like the code is based on the possible values of the field [MergeableState](https://docs.github.com/en/graphql/reference/enums#mergeablestate) in the GraphQL API. But based on the community discussions listed below the possible values are actually the ones listed for [MergeStateStatus](https://docs.github.com/en/graphql/reference/enums#mergestatestatus) in the GraphQL API.

https://github.com/orgs/community/discussions/24299#discussioncomment-3243704
https://github.com/orgs/community/discussions/21886


