### PR TITLE
fix: github now requires explicit make_latest=true on update

### DIFF
--- a/scm/driver/github/release.go
+++ b/scm/driver/github/release.go
@@ -32,6 +32,7 @@ type releaseInput struct {
 	Commitish   string `json:"target_commitish,omitempty"`
 	Draft       bool   `json:"draft"`
 	Prerelease  bool   `json:"prerelease"`
+	MakeLatest  string `json:"make_latest"`
 }
 
 func (s *releaseService) Find(ctx context.Context, repo string, id int) (*scm.Release, *scm.Response, error) {
@@ -97,6 +98,9 @@ func (s *releaseService) Update(ctx context.Context, repo string, id int, input 
 	}
 	in.Draft = input.Draft
 	in.Prerelease = input.Prerelease
+	if !(in.Prerelease || in.Draft) {
+		in.MakeLatest = "true"
+	}
 	out := new(release)
 	res, err := s.client.do(ctx, "PATCH", path, in, out)
 	return convertRelease(out), res, err


### PR DESCRIPTION
I noticed that new releases of jx don't get the badge **Latest**. That should be done by https://github.com/jenkins-x/jx3-versions/blob/master/.lighthouse/jenkins-x/release.yaml#L46, but it currently only remove the **Pre-release** badge. (I have added the **Latest** badge manually.) After debugging the http requests I noticed that adding make_latest=true does add the **Latest** badge. That also conforms with the current documentation. I can't find any information from GitHub about this API change though.