### PR TITLE
Add modifiy field in changes APIs in Bitbucket server (stash)

### DIFF
--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -253,10 +253,11 @@ func convertDiffstats(from *diffstats) []*scm.Change {
 
 func convertDiffstat(from *diffstat) *scm.Change {
 	to := &scm.Change{
-		Path:    from.Path.ToString,
-		Added:   from.Type == "ADD",
-		Renamed: from.Type == "MOVE",
-		Deleted: from.Type == "DELETE",
+		Path:     from.Path.ToString,
+		Added:    from.Type == "ADD",
+		Modified: from.Type == "MODIFY",
+		Renamed:  from.Type == "MOVE",
+		Deleted:  from.Type == "DELETE",
 	}
 	if from.SrcPath != nil {
 		to.PreviousPath = from.SrcPath.ToString

--- a/scm/driver/stash/testdata/changes.json.golden
+++ b/scm/driver/stash/testdata/changes.json.golden
@@ -2,12 +2,14 @@
     {
         "Path": ".gitignore",
         "Added": false,
+        "Modified": false,
         "Renamed": false,
         "Deleted": true
     },
     {
         "Path": "COPYING",
         "Added": false,
+        "Modified": true,
         "Renamed": false,
         "Deleted": false
     },
@@ -15,12 +17,14 @@
         "Path": "README.md",
         "PreviousPath": "README",
         "Added": false,
+        "Modified": false,
         "Renamed": true,
         "Deleted": false
     },
     {
         "Path": "main.go",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     }

--- a/scm/driver/stash/testdata/pr_change.json.golden
+++ b/scm/driver/stash/testdata/pr_change.json.golden
@@ -2,24 +2,28 @@
     {
         "Path": "COPYING",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     },
     {
         "Path": "README",
         "Added": false,
+        "Modified": false,
         "Renamed": false,
         "Deleted": true
     },
     {
         "Path": "README.md",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     },
     {
         "Path": "main.go",
         "Added": true,
+        "Modified": false,
         "Renamed": false,
         "Deleted": false
     }

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -94,6 +94,7 @@ type (
 		Path         string
 		PreviousPath string
 		Added        bool
+		Modified     bool
 		Renamed      bool
 		Deleted      bool
 		Patch        string


### PR DESCRIPTION
file's modification status is missing in response of Pull Request changes and commit changes APIs. this PR addresses that issue in Bitbucket server (stash).