### PR TITLE
Implement Content Add Endpoint for Bitbucket Server (stash)

### DIFF
--- a/scm/driver/stash/content.go
+++ b/scm/driver/stash/content.go
@@ -33,7 +33,18 @@ func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*s
 }
 
 func (s *contentService) Create(ctx context.Context, repo, path string, params *scm.ContentParams) (*scm.Response, error) {
-	return nil, scm.ErrNotSupported
+	namespace, repoName := scm.Split(repo)
+	endpoint := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/browse/%s", namespace, repoName, path)
+	message := params.Message
+	if params.Signature.Name != "" && params.Signature.Email != "" {
+		message = fmt.Sprintf("%s\nSigned-off-by: %s <%s>", params.Message, params.Signature.Name, params.Signature.Email)
+	}
+	in := &contentCreateUpdate{
+		Message: message,
+		Branch:  params.Branch,
+		Content: params.Data,
+	}
+	return s.client.do(ctx, "PUT", endpoint, in, nil)
 }
 
 func (s *contentService) Update(ctx context.Context, repo, path string, params *scm.ContentParams) (*scm.Response, error) {
@@ -42,4 +53,11 @@ func (s *contentService) Update(ctx context.Context, repo, path string, params *
 
 func (s *contentService) Delete(ctx context.Context, repo, path string, params *scm.ContentParams) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
+}
+
+type contentCreateUpdate struct {
+	Branch  string `json:"branch"`
+	Message string `json:"message"`
+	Content []byte `json:"content"`
+	Sha     string `json:"sourceCommitId"`
 }

--- a/scm/driver/stash/multipart.go
+++ b/scm/driver/stash/multipart.go
@@ -1,0 +1,26 @@
+package stash
+
+import "mime/multipart"
+
+type MultipartWriter struct {
+	Writer *multipart.Writer
+	Error  error
+}
+
+func (mw *MultipartWriter) Write(f, v string) {
+	if mw.Error != nil {
+		return
+	}
+	if v == "" {
+		return
+	}
+	mw.Error = mw.Writer.WriteField(f, v)
+}
+
+func (mw *MultipartWriter) Close() {
+	mw.Writer.Close()
+}
+
+func (mw *MultipartWriter) FormDataContentType() string {
+	return mw.Writer.FormDataContentType()
+}

--- a/scm/driver/stash/testdata/content_create.json
+++ b/scm/driver/stash/testdata/content_create.json
@@ -1,0 +1,21 @@
+{
+    "id": "abcdef0123abcdef4567abcdef8987abcdef6543",
+    "displayId": "abcdef0123a",
+    "author": {
+        "name": "Zaki",
+        "emailAddress": "zaki@example.com"
+    },
+    "authorTimestamp": 1734286823374,
+    "committer": {
+        "name": "Zaki",
+        "emailAddress": "zaki@example.com"
+    },
+    "committerTimestamp": 1734286823374,
+    "message": "WIP on feature 1",
+    "parents": [
+        {
+            "id": "abcdef0123abcdef4567abcdef8987abcdef6543",
+            "displayId": "abcdef0"
+        }
+    ]
+}


### PR DESCRIPTION
for Bitbucket Server (Stash) [content add](https://developer.atlassian.com/server/bitbucket/rest/v903/api-group-repository/#api-api-latest-projects-projectkey-repos-repositoryslug-browse-path-put) endpoint wasn't implemented before, this adds the endpoint and unit test for it.