### PR TITLE
Implement Content List Endpoint for Bitbucket Server (stash)

### DIFF
--- a/scm/content.go
+++ b/scm/content.go
@@ -43,7 +43,7 @@ type (
 		Find(ctx context.Context, repo, path, ref string) (*Content, *Response, error)
 
 		// List the files or directories at the given path
-		List(ctx context.Context, repo, path, ref string) ([]*FileEntry, *Response, error)
+		List(ctx context.Context, repo, path, ref string, opts *ListOptions) ([]*FileEntry, *Response, error)
 
 		// Create creates a new repository file.
 		Create(ctx context.Context, repo, path string, params *ContentParams) (*Response, error)

--- a/scm/driver/azure/content.go
+++ b/scm/driver/azure/content.go
@@ -127,7 +127,7 @@ func (s *contentService) Delete(ctx context.Context, repo, path string, params *
 	return res, err
 }
 
-func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
+func (s *contentService) List(ctx context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
 	// https://docs.microsoft.com/en-us/rest/api/azure/devops/git/items/list?view=azure-devops-rest-6.0
 	ro, err := decodeRepo(repo)
 	if err != nil {

--- a/scm/driver/azure/content_test.go
+++ b/scm/driver/azure/content_test.go
@@ -155,6 +155,7 @@ func TestContentList(t *testing.T) {
 		"ORG/PROJ/REPOID",
 		"",
 		"",
+		&scm.ListOptions{},
 	)
 	if err != nil {
 		t.Error(err)

--- a/scm/driver/azure/integration/content_test.go
+++ b/scm/driver/azure/integration/content_test.go
@@ -72,7 +72,7 @@ func TestContentManagement(t *testing.T) {
 		{
 			Name: "list content",
 			Test: func(t *testing.T) {
-				files, res, err := client.Contents.List(context.Background(), repoFQ(testRepoName), "", "")
+				files, res, err := client.Contents.List(context.Background(), repoFQ(testRepoName), "", "", &scm.ListOptions{})
 				if err != nil {
 					t.Errorf("could not list content: %v", err)
 				}
@@ -89,7 +89,7 @@ func TestContentManagement(t *testing.T) {
 		{
 			Name: "update the main.go file",
 			Test: func(t *testing.T) {
-				latestCommit, _, err := client.Contents.List(context.Background(), repoFQ(testRepoName), "", "main")
+				latestCommit, _, err := client.Contents.List(context.Background(), repoFQ(testRepoName), "", "main", &scm.ListOptions{})
 				if err != nil {
 					t.Errorf("could not get the latest commit: %v", err)
 				}
@@ -116,7 +116,7 @@ func TestContentManagement(t *testing.T) {
 		{
 			Name: "delete the main.go file",
 			Test: func(t *testing.T) {
-				latestCommit, _, err := client.Contents.List(context.Background(), repoFQ(testRepoName), "", "main")
+				latestCommit, _, err := client.Contents.List(context.Background(), repoFQ(testRepoName), "", "main", &scm.ListOptions{})
 				if err != nil {
 					t.Errorf("could not get the latest commit: %v", err)
 				}

--- a/scm/driver/bitbucket/content.go
+++ b/scm/driver/bitbucket/content.go
@@ -26,7 +26,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	}, res, err
 }
 
-func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
+func (s *contentService) List(ctx context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 

--- a/scm/driver/fake/content.go
+++ b/scm/driver/fake/content.go
@@ -43,7 +43,7 @@ func (c contentService) Find(_ context.Context, repo, path, ref string) (*scm.Co
 	}, nil, nil
 }
 
-func (c contentService) List(_ context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
+func (c contentService) List(_ context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
 	dir, err := c.path(repo, path, ref)
 	if err != nil {
 		return nil, nil, err

--- a/scm/driver/fake/content_test.go
+++ b/scm/driver/fake/content_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jenkins-x/go-scm/scm"
+
 	"github.com/jenkins-x/go-scm/scm/driver/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -18,7 +20,7 @@ func TestContent(t *testing.T) {
 	sha := "master"
 
 	repo := "myorg/myrepo"
-	files, _, err := client.Contents.List(ctx, repo, "/", sha)
+	files, _, err := client.Contents.List(ctx, repo, "/", sha, &scm.ListOptions{})
 	require.NoError(t, err, "could not list files in repo %s", repo)
 	require.Len(t, files, 2, "should have found 2 files")
 

--- a/scm/driver/gitea/content.go
+++ b/scm/driver/gitea/content.go
@@ -36,7 +36,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	}, toSCMResponse(resp), err
 }
 
-func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
+func (s *contentService) List(ctx context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
 	namespace, name := scm.Split(repo)
 
 	ref = strings.TrimPrefix(ref, "refs/heads/")

--- a/scm/driver/gitea/content_test.go
+++ b/scm/driver/gitea/content_test.go
@@ -70,6 +70,7 @@ func TestContentList(t *testing.T) {
 		"go-gitea/gitea",
 		"/",
 		"",
+		&scm.ListOptions{},
 	)
 	if err != nil {
 		t.Error(err)

--- a/scm/driver/github/content.go
+++ b/scm/driver/github/content.go
@@ -28,7 +28,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	}, res, err
 }
 
-func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
+func (s *contentService) List(ctx context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
 	endpoint := fmt.Sprintf("repos/%s/contents/%s?ref=%s", repo, path, ref)
 	out := []*entry{}
 	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)

--- a/scm/driver/github/content_test.go
+++ b/scm/driver/github/content_test.go
@@ -72,6 +72,7 @@ func TestContentList(t *testing.T) {
 		"octocat/hello-world",
 		"README",
 		"7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+		&scm.ListOptions{},
 	)
 	if err != nil {
 		t.Error(err)

--- a/scm/driver/gitlab/content.go
+++ b/scm/driver/gitlab/content.go
@@ -39,7 +39,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	}, res, err
 }
 
-func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
+func (s *contentService) List(ctx context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
 	endpoint := fmt.Sprintf("api/v4/projects/%s/repository/tree?path=%s&ref=%s", encode(repo), path, ref)
 	out := []*entry{}
 	res, err := s.client.do(ctx, "GET", endpoint, nil, &out)

--- a/scm/driver/gitlab/content_test.go
+++ b/scm/driver/gitlab/content_test.go
@@ -74,6 +74,7 @@ func TestContentList(t *testing.T) {
 		"diaspora/diaspora",
 		"app/models/key.rb",
 		"7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+		&scm.ListOptions{},
 	)
 	if err != nil {
 		t.Error(err)

--- a/scm/driver/gogs/content.go
+++ b/scm/driver/gogs/content.go
@@ -29,7 +29,7 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	}, res, err
 }
 
-func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
+func (s *contentService) List(ctx context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
 	return nil, nil, scm.ErrNotSupported
 }
 

--- a/scm/driver/stash/content.go
+++ b/scm/driver/stash/content.go
@@ -28,8 +28,16 @@ func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm
 	}, res, err
 }
 
-func (s *contentService) List(ctx context.Context, repo, path, ref string) ([]*scm.FileEntry, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+func (s *contentService) List(ctx context.Context, repo, path, ref string, opts *scm.ListOptions) ([]*scm.FileEntry, *scm.Response, error) {
+	namespace, name := scm.Split(repo)
+	endpoint := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/files/%s?at=%s&%s", namespace, name, path, ref, encodeListOptions(opts))
+	out := new(contents)
+	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
+	if !out.pagination.LastPage.Bool {
+		res.Page.First = 1
+		res.Page.Next = opts.Page + 1
+	}
+	return convertFileEntryList(out), res, err
 }
 
 func (s *contentService) Create(ctx context.Context, repo, path string, params *scm.ContentParams) (*scm.Response, error) {
@@ -55,9 +63,24 @@ func (s *contentService) Delete(ctx context.Context, repo, path string, params *
 	return nil, scm.ErrNotSupported
 }
 
+type contents struct {
+	pagination
+	Values []string `json:"values"`
+}
+
 type contentCreateUpdate struct {
 	Branch  string `json:"branch"`
 	Message string `json:"message"`
 	Content []byte `json:"content"`
 	Sha     string `json:"sourceCommitId"`
+}
+
+func convertFileEntryList(from *contents) []*scm.FileEntry {
+	var to []*scm.FileEntry
+	for _, v := range from.Values {
+		to = append(to, &scm.FileEntry{
+			Path: v,
+		})
+	}
+	return to
 }

--- a/scm/driver/stash/content_test.go
+++ b/scm/driver/stash/content_test.go
@@ -45,6 +45,27 @@ func TestContentFind(t *testing.T) {
 	}
 }
 
+func TestContentList(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/files/pkg").
+		MatchParam("at", "5c64a07cd6c0f21b753bf261ef059c7e7633c50a").
+		Reply(200).
+		Type("text/plain").
+		File("testdata/content_list.json")
+
+	client, _ := New("http://example.com:7990")
+	_, resp, err := client.Contents.List(context.Background(), "PRJ/my-repo", "pkg", "5c64a07cd6c0f21b753bf261ef059c7e7633c50a", &scm.ListOptions{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.Status != 200 {
+		t.Errorf("got %d", resp.Status)
+	}
+}
+
 func TestContentCreate(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/stash/testdata/content_list.json
+++ b/scm/driver/stash/testdata/content_list.json
@@ -1,0 +1,10 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    ".tekton/pr-1.yaml",
+    ".tekton/pr-2.yaml"
+  ],
+  "start": 0
+}

--- a/scm/factory/examples/contentlist/main.go
+++ b/scm/factory/examples/contentlist/main.go
@@ -35,7 +35,7 @@ func main() {
 	fullRepo := scm.Join(owner, repo)
 
 	fmt.Printf("getting content for repository %s/%s and path: %s with ref: %s\n", owner, repo, path, ref)
-	files, _, err := client.Contents.List(ctx, fullRepo, path, ref)
+	files, _, err := client.Contents.List(ctx, fullRepo, path, ref, &scm.ListOptions{})
 	if err != nil {
 		helpers.Fail(err)
 		return


### PR DESCRIPTION
[Content List](https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8297638624) endpoint in Bitbucket server lists the content of a directory recusively, this PR implements it.