### PR TITLE
Implement CreateRef Endpoint in Git Service for Bitbucket Server (stash)

### DIFF
--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -41,7 +41,15 @@ func (s *gitService) FindRef(ctx context.Context, repo, ref string) (string, *sc
 }
 
 func (s *gitService) CreateRef(ctx context.Context, repo, ref, sha string) (*scm.Reference, *scm.Response, error) {
-	return nil, nil, scm.ErrNotSupported
+	namespace, repoName := scm.Split(repo)
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches", namespace, repoName)
+	out := new(branch)
+	in := &createBranch{
+		Name:       ref,
+		StartPoint: sha,
+	}
+	resp, err := s.client.do(ctx, "POST", path, in, out)
+	return convertBranch(out), resp, err
 }
 
 func (s *gitService) DeleteRef(ctx context.Context, repo, ref string) (*scm.Response, error) {
@@ -149,6 +157,11 @@ type branch struct {
 	LatestCommit    string `json:"latestCommit"`
 	LatestChangeset string `json:"latestChangeset"`
 	IsDefault       bool   `json:"isDefault"`
+}
+
+type createBranch struct {
+	Name       string `json:"name"`
+	StartPoint string `json:"startPoint"`
 }
 
 type branches struct {

--- a/scm/driver/stash/git_test.go
+++ b/scm/driver/stash/git_test.go
@@ -44,6 +44,34 @@ func TestGitFindCommit(t *testing.T) {
 	}
 }
 
+func TestGitCreateRef(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com:7990").
+		Post("/rest/api/1.0/projects/PRJ/repos/my-repo/branches").
+		Reply(200).
+		Type("application/json").
+		File("testdata/create_ref.json")
+
+	client, _ := New("http://example.com:7990")
+	got, _, err := client.Git.CreateRef(context.Background(), "PRJ/my-repo", "scm-branch", "refs/heads/main")
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := new(scm.Reference)
+	raw, _ := os.ReadFile("testdata/create_ref.json.golden")
+	err = json.Unmarshal(raw, &want)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
 func TestGitFindBranch(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/stash/testdata/create_ref.json
+++ b/scm/driver/stash/testdata/create_ref.json
@@ -1,0 +1,8 @@
+{
+  "id": "refs/heads/scm-branch",
+  "displayId": "scm-branch",
+  "type": "BRANCH",
+  "latestCommit": "8d51122def5632836d1cb1026e879069e10a1e13",
+  "latestChangeset": "8d51122def5632836d1cb1026e879069e10a1e13",
+  "isDefault": false
+}

--- a/scm/driver/stash/testdata/create_ref.json.golden
+++ b/scm/driver/stash/testdata/create_ref.json.golden
@@ -1,0 +1,5 @@
+{
+  "Name": "scm-branch",
+  "Path": "refs/heads/scm-branch",
+  "Sha": "8d51122def5632836d1cb1026e879069e10a1e13"
+}


### PR DESCRIPTION
implements create ref endpoint which is intended for create branch in git service of Bitbucket server (stash).