### PR TITLE
Fetch Default Branch for a Repository in Find Repository Endpoint for Bitbucket Server (stash)

### DIFF
--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -296,7 +296,17 @@ func (s *repositoryService) Find(ctx context.Context, repo string) (*scm.Reposit
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s", namespace, name)
 	out := new(repository)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	return convertRepository(out), res, err
+	outputRepo := convertRepository(out)
+
+	// default value for repository.Branch is `master` but it may differ for other
+	// repositories as a repository can have `main` or `trunk` as default branch.
+	branch := new(branch)
+	pathBranch := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches/default", namespace, name)
+	_, errBranch := s.client.do(ctx, "GET", pathBranch, nil, branch)
+	if errBranch == nil {
+		outputRepo.Branch = branch.DisplayID
+	}
+	return outputRepo, res, err
 }
 
 // FindHook returns a repository hook.

--- a/scm/driver/stash/repo_test.go
+++ b/scm/driver/stash/repo_test.go
@@ -91,6 +91,12 @@ func TestRepositoryFind(t *testing.T) {
 		Type("application/json").
 		File("testdata/repo.json")
 
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/branches/default").
+		Reply(200).
+		Type("application/json").
+		File("testdata/default_branch.json")
+
 	client, _ := New("http://example.com:7990")
 	got, _, err := client.Repositories.Find(context.Background(), "PRJ/my-repo")
 	if err != nil {

--- a/scm/driver/stash/testdata/default_branch.json
+++ b/scm/driver/stash/testdata/default_branch.json
@@ -1,0 +1,8 @@
+{
+  "id": "refs/heads/master",
+  "displayId": "master",
+  "type": "BRANCH",
+  "latestCommit": "8d51122def5632836d1cb1026e879069e10a1e13",
+  "latestChangeset": "8d51122def5632836d1cb1026e879069e10a1e13",
+  "isDefault": true
+}

--- a/scm/repo.go
+++ b/scm/repo.go
@@ -28,7 +28,7 @@ type (
 		Name      string
 		FullName  string
 		Perm      *Perm
-		Branch    string
+		Branch    string // default branch of the repository
 		Private   bool
 		Archived  bool
 		Clone     string


### PR DESCRIPTION
fetched default branch for a repository because the default branch name may differ across repositories. [drone/go-scm](https://github.com/drone/go-scm/) also [does](https://github.com/drone/go-scm/blob/d9147fbe059d891b3bdb77adf8f2cd6f7044d427/scm/driver/stash/repo.go#L109) the same.