### PR TITLE
Implement Delete Pull Request Endpoint in Bitbucket Server (stash)

### DIFF
--- a/scm/driver/azure/pr.go
+++ b/scm/driver/azure/pr.go
@@ -169,6 +169,10 @@ func (s *pullService) Create(ctx context.Context, repo string, input *scm.PullRe
 	return convertPullRequest(out), res, err
 }
 
+func (s *pullService) DeletePullRequest(ctx context.Context, repo string, prID int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
 type prInput struct {
 	SourceRefName string `json:"sourceRefName"`
 	TargetRefName string `json:"targetRefName"`

--- a/scm/driver/bitbucket/pr.go
+++ b/scm/driver/bitbucket/pr.go
@@ -284,6 +284,10 @@ func (s *pullService) UnrequestReview(ctx context.Context, repo string, number i
 	return nil, scm.ErrNotSupported
 }
 
+func (s *pullService) DeletePullRequest(ctx context.Context, repo string, prID int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
 type prSource struct {
 	Commit struct {
 		Type   string `json:"type"`

--- a/scm/driver/fake/pr.go
+++ b/scm/driver/fake/pr.go
@@ -376,3 +376,7 @@ func (s *pullService) SetMilestone(ctx context.Context, repo string, prID, numbe
 func (s *pullService) ClearMilestone(ctx context.Context, repo string, prID int) (*scm.Response, error) {
 	return nil, scm.ErrNotSupported
 }
+
+func (s *pullService) DeletePullRequest(ctx context.Context, repo string, prID int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}

--- a/scm/driver/gitea/pr.go
+++ b/scm/driver/gitea/pr.go
@@ -144,6 +144,10 @@ func (s *pullService) UnrequestReview(ctx context.Context, repo string, number i
 	return s.UnassignIssue(ctx, repo, number, logins)
 }
 
+func (s *pullService) DeletePullRequest(ctx context.Context, repo string, prID int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
 //
 // native data structure conversion
 //

--- a/scm/driver/github/pr.go
+++ b/scm/driver/github/pr.go
@@ -158,6 +158,10 @@ func (s *pullService) UnrequestReview(ctx context.Context, repo string, number i
 	return res, nil
 }
 
+func (s *pullService) DeletePullRequest(ctx context.Context, repo string, prID int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
 func prepareReviewersBody(logins []string, org string) (prReviewers, error) {
 	body := prReviewers{}
 	var errors []error

--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -266,6 +266,10 @@ func (s *pullService) ClearMilestone(ctx context.Context, repo string, prID int)
 	return res, err
 }
 
+func (s *pullService) DeletePullRequest(ctx context.Context, repo string, prID int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
 type updateMergeRequestOptions struct {
 	Title              *string `json:"title,omitempty"`
 	Description        *string `json:"description,omitempty"`

--- a/scm/driver/gogs/pr.go
+++ b/scm/driver/gogs/pr.go
@@ -111,6 +111,10 @@ func (s *pullService) ClearMilestone(ctx context.Context, repo string, prID int)
 	return nil, scm.ErrNotSupported
 }
 
+func (s *pullService) DeletePullRequest(ctx context.Context, repo string, prID int) (*scm.Response, error) {
+	return nil, scm.ErrNotSupported
+}
+
 //
 // native data structures
 //

--- a/scm/driver/stash/pr_test.go
+++ b/scm/driver/stash/pr_test.go
@@ -440,3 +440,28 @@ func TestPullListLabels(t *testing.T) {
 		t.Log(diff)
 	}
 }
+
+func TestPullRequestDelete(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com:7990").
+		Get("rest/api/1.0/projects/PRJ/repos/my-repo/pull-requests/1").
+		Reply(200).
+		Type("application/json").
+		File("testdata/pr.json")
+
+	gock.New("http://example.com:7990").
+		Delete("rest/api/1.0/projects/PRJ/repos/my-repo/pull-requests/1").
+		Reply(204).
+		Type("application/json")
+
+	client, _ := New("http://example.com:7990")
+	resp, err := client.PullRequests.DeletePullRequest(context.Background(), "PRJ/my-repo", 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.Status != 204 {
+		t.Errorf("DeletePullRequest returned %v", resp.Status)
+	}
+}

--- a/scm/pr.go
+++ b/scm/pr.go
@@ -193,6 +193,9 @@ type (
 
 		// ClearMilestone removes the milestone from a pull request
 		ClearMilestone(ctx context.Context, repo string, prID int) (*Response, error)
+
+		// DeletePullRequest deletes a pull request from a repo.
+		DeletePullRequest(ctx context.Context, repo string, prID int) (*Response, error)
 	}
 )
 


### PR DESCRIPTION
In Bitbucket server it is allowed to delete a pull request, this PR implements that [endpoint](https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8287244352).