### PR TITLE
Add GetDefaultBranch Endpoint in Git Service

### DIFF
--- a/scm/driver/azure/git.go
+++ b/scm/driver/azure/git.go
@@ -131,6 +131,10 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, source, target st
 	return convertChangeList(changes), res, err
 }
 
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}
+
 type gitRef struct {
 	Name        string `json:"name"`
 	OldObjectID string `json:"oldObjectId"`

--- a/scm/driver/bitbucket/git.go
+++ b/scm/driver/bitbucket/git.go
@@ -132,6 +132,14 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 	return convertDiffstats(out), res, err
 }
 
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	repository, res, err := s.client.Repositories.Find(ctx, repo)
+	if err != nil {
+		return nil, res, err
+	}
+	return s.FindBranch(ctx, repo, repository.Branch)
+}
+
 type branch struct {
 	Type   string `json:"type"`
 	Name   string `json:"name"`

--- a/scm/driver/fake/git.go
+++ b/scm/driver/fake/git.go
@@ -66,3 +66,7 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 func (s *gitService) ListTags(ctx context.Context, repo string, opts *scm.ListOptions) ([]*scm.Reference, *scm.Response, error) {
 	panic("implement me")
 }
+
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	return nil, nil, scm.ErrNotSupported
+}

--- a/scm/driver/gitea/git.go
+++ b/scm/driver/gitea/git.go
@@ -102,6 +102,14 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	repository, res, err := s.client.Repositories.Find(ctx, repo)
+	if err != nil {
+		return nil, res, err
+	}
+	return s.FindBranch(ctx, repo, repository.Branch)
+}
+
 //
 // native data structures
 //

--- a/scm/driver/github/git.go
+++ b/scm/driver/github/git.go
@@ -115,6 +115,14 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 	return convertChangeList(out.Files), res, err
 }
 
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	repository, res, err := s.client.Repositories.Find(ctx, repo)
+	if err != nil {
+		return nil, res, err
+	}
+	return s.FindBranch(ctx, repo, repository.Branch)
+}
+
 type branch struct {
 	Name      string `json:"name"`
 	Commit    commit `json:"commit"`

--- a/scm/driver/gitlab/git.go
+++ b/scm/driver/gitlab/git.go
@@ -123,6 +123,14 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 	return convertChangeList(out.Diffs), res, err
 }
 
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	repository, res, err := s.client.Repositories.Find(ctx, repo)
+	if err != nil {
+		return nil, res, err
+	}
+	return s.FindBranch(ctx, repo, repository.Branch)
+}
+
 type compare struct {
 	Diffs []*change `json:"diffs"`
 }

--- a/scm/driver/gogs/git.go
+++ b/scm/driver/gogs/git.go
@@ -69,6 +69,14 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 	return nil, nil, scm.ErrNotSupported
 }
 
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	repository, res, err := s.client.Repositories.Find(ctx, repo)
+	if err != nil {
+		return nil, res, err
+	}
+	return s.FindBranch(ctx, repo, repository.Branch)
+}
+
 //
 // native data structures
 //

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -153,6 +153,14 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 	return convertDiffstats(out), res, err
 }
 
+func (s *gitService) GetDefaultBranch(ctx context.Context, repo string) (*scm.Reference, *scm.Response, error) {
+	namespace, name := scm.Split(repo)
+	branch := new(branch)
+	pathBranch := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches/default", namespace, name)
+	resp, err := s.client.do(ctx, "GET", pathBranch, nil, branch)
+	return convertBranch(branch), resp, err
+}
+
 type deleteRefInput struct {
 	DryRun   bool   `json:"dryRun,omitempty"`
 	EndPoint string `json:"endPoint,omitempty"`

--- a/scm/driver/stash/git_test.go
+++ b/scm/driver/stash/git_test.go
@@ -274,3 +274,31 @@ func TestGitCompareCommits(t *testing.T) {
 		t.Log(diff)
 	}
 }
+
+func TestGitGetDefaultBranch(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/branches/default").
+		Reply(200).
+		Type("application/json").
+		File("testdata/default_branch.json")
+
+	client, _ := New("http://example.com:7990")
+	got, _, err := client.Git.GetDefaultBranch(context.Background(), "PRJ/my-repo")
+	if err != nil {
+		t.Error(err)
+	}
+
+	want := &scm.Reference{}
+	raw, _ := os.ReadFile("testdata/default_branch.json.golden")
+	err = json.Unmarshal(raw, &want)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}

--- a/scm/driver/stash/testdata/default_branch.json.golden
+++ b/scm/driver/stash/testdata/default_branch.json.golden
@@ -1,0 +1,5 @@
+{
+  "Name": "master",
+  "Path": "refs/heads/master",
+  "Sha": "8d51122def5632836d1cb1026e879069e10a1e13"
+}

--- a/scm/git.go
+++ b/scm/git.go
@@ -69,6 +69,9 @@ type (
 		// FindBranch finds a git branch by name.
 		FindBranch(ctx context.Context, repo, name string) (*Reference, *Response, error)
 
+		// GetDefaultBranch finds default branch of the repo.
+		GetDefaultBranch(ctx context.Context, repo string) (*Reference, *Response, error)
+
 		// FindCommit finds a git commit by ref.
 		FindCommit(ctx context.Context, repo, ref string) (*Commit, *Response, error)
 


### PR DESCRIPTION
Users should be able to fetch Default branch for a repository. This PR implements GetDefaultBranch for following git providers:
- [ ] Azure DevOps 
- [x] Bitbucket Cloud
- [x] Gitea
- [x] GitHub
- [x] GitLab
- [x] Gogs
- [x] Bitbucket Server (AKA Stash)