### PR TITLE
fix: IsScmNotFound should check for string `Not Found`

### DIFF
--- a/scm/util.go
+++ b/scm/util.go
@@ -95,7 +95,7 @@ func IsScmNotFound(err error) bool {
 	if err != nil {
 		// I think that we should instead rely on the http status (404)
 		// until jenkins-x go-scm is updated t return that in the error this works for github and gitlab
-		return strings.Contains(err.Error(), ErrNotFound.Error())
+		return strings.Contains(err.Error(), "Not Found")
 	}
 	return false
 }


### PR DESCRIPTION
ErrNotFound.Error() used to be `Not Found`, but it was changed to `not Found` by https://github.com/jenkins-x/go-scm/pull/334, and break `jx changelog create` for gitlab.