### PR TITLE
fix: Added Missing Statuses for Commit Build Status in Bitbucket Server (Stash)

### DIFF
--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -580,8 +580,14 @@ func convertFromState(from scm.State) string {
 		return "INPROGRESS"
 	case scm.StateSuccess:
 		return "SUCCESSFUL"
-	default:
+	case scm.StateFailure:
 		return "FAILED"
+	case scm.StateCanceled:
+		return "CANCELLED"
+	case scm.StateUnknown:
+		return "UNKNOWN"
+	default:
+		return "UNKNOWN"
 	}
 }
 

--- a/scm/driver/stash/repo_test.go
+++ b/scm/driver/stash/repo_test.go
@@ -564,11 +564,11 @@ func TestConvertFromState(t *testing.T) {
 	}{
 		{
 			src: scm.StateCanceled,
-			dst: "FAILED",
+			dst: "CANCELLED",
 		},
 		{
 			src: scm.StateError,
-			dst: "FAILED",
+			dst: "UNKNOWN",
 		},
 		{
 			src: scm.StateFailure,
@@ -588,7 +588,7 @@ func TestConvertFromState(t *testing.T) {
 		},
 		{
 			src: scm.StateUnknown,
-			dst: "FAILED",
+			dst: "UNKNOWN",
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Added Missing Statuses for Commit Build Status and made default status as UNKNOWN which was previously "FAILED" and that doesn't make sense to keep it failed.
https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/