### PR TITLE
Fix Bitbucket Server Group-Based Permission Checks

### DIFF
--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -73,7 +73,7 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 		res.Page.Next = opts.Page + 1
 	}
 	for _, participant := range out.Values {
-		if participant.User.Name == user || participant.User.Slug == user {
+		if isRequestedUser(user, participant.User.Name, participant.User.Slug) {
 			return true, res, nil
 		}
 	}
@@ -89,12 +89,16 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 			continue
 		}
 		for _, member := range users {
-			if member.Name == user || member.Slug == user {
+			if isRequestedUser(user, member.Name, member.Slug) {
 				return true, res, nil
 			}
 		}
 	}
 	return false, res, nil
+}
+
+func isRequestedUser(requested, name, slug string) bool {
+	return name == requested || slug == requested
 }
 
 // getProjectGroups returns the groups which have some permissions in the project

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -7,6 +7,7 @@ package stash
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/jenkins-x/go-scm/scm"
 )
@@ -113,7 +114,7 @@ func getProjectGroups(ctx context.Context, org string, os *organizationService, 
 
 // usersInGroups returns the members/users in a group
 func usersInGroups(ctx context.Context, group string, os *organizationService, opts *scm.ListOptions) ([]*member, error) {
-	path := fmt.Sprintf("rest/api/1.0/admin/groups/more-members?context=%s&%s", group, encodeListOptions(opts))
+	path := fmt.Sprintf("rest/api/1.0/admin/groups/more-members?context=%s&%s", url.QueryEscape(group), encodeListOptions(opts))
 	out := new(members)
 	res, err := os.client.do(ctx, "GET", path, nil, out)
 	if err != nil {

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -82,19 +82,26 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 	if err != nil {
 		return false, res, err
 	}
+	if isUserInGroups(ctx, user, groups, s.client, opts) {
+		return true, res, nil
+	}
+	return false, res, nil
+}
+
+func isUserInGroups(ctx context.Context, requestedUser string, groups []*projGroup, client *wrapper, opts *scm.ListOptions) bool {
 	for _, pgroup := range groups {
-		// Get list of users in a group
-		users, err := usersInGroups(ctx, pgroup.Group.Name, s.client, opts)
+		users, err := usersInGroups(ctx, pgroup.Group.Name, client, opts)
 		if err != nil {
 			continue
 		}
 		for _, member := range users {
-			if isRequestedUser(user, member.Name, member.Slug) {
-				return true, res, nil
+			if isRequestedUser(requestedUser, member.Name, member.Slug) {
+				return true
 			}
 		}
 	}
-	return false, res, nil
+
+	return false
 }
 
 func isRequestedUser(requested, name, slug string) bool {

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -46,7 +46,7 @@ func (s *organizationService) ListTeamMembers(ctx context.Context, id int, role 
 
 func (s *organizationService) ListOrgMembers(ctx context.Context, org string, opts *scm.ListOptions) ([]*scm.TeamMember, *scm.Response, error) {
 	opts.Size = 1000
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/permissions/users?%s", org, encodeListOptions(opts))
+	path := projectUsersPermissionsPath(org, opts)
 	out := new(participants)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	if !out.pagination.LastPage.Bool {
@@ -62,7 +62,7 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 		Size: 1000,
 	}
 	// Check if user has permissions in the project
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/permissions/users?%s", org, encodeListOptions(opts))
+	path := projectUsersPermissionsPath(org, opts)
 	out := new(participants)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	if err != nil {
@@ -131,7 +131,7 @@ func (s *organizationService) IsAdmin(ctx context.Context, org, user string) (bo
 	opts := &scm.ListOptions{
 		Size: 1000,
 	}
-	path := fmt.Sprintf("rest/api/1.0/projects/%s/permissions/users?%s", org, encodeListOptions(opts))
+	path := projectUsersPermissionsPath(org, opts)
 	out := new(participants)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	if !out.pagination.LastPage.Bool {
@@ -170,7 +170,7 @@ func (s *organizationService) ListMemberships(ctx context.Context, opts *scm.Lis
 }
 
 func convertParticipantsToTeamMembers(from *participants) []*scm.TeamMember {
-	var teamMembers []*scm.TeamMember
+	teamMembers := make([]*scm.TeamMember, 0, len(from.Values))
 	for _, f := range from.Values {
 		teamMembers = append(teamMembers, &scm.TeamMember{Login: f.User.Name})
 	}
@@ -178,11 +178,15 @@ func convertParticipantsToTeamMembers(from *participants) []*scm.TeamMember {
 }
 
 func convertProjectList(from []project) []*scm.Organization {
-	var to []*scm.Organization
+	to := make([]*scm.Organization, 0, len(from))
 	for _, v := range from {
 		to = append(to, convertProject(v))
 	}
 	return to
+}
+
+func projectUsersPermissionsPath(org string, opts *scm.ListOptions) string {
+	return fmt.Sprintf("rest/api/1.0/projects/%s/permissions/users?%s", org, encodeListOptions(opts))
 }
 
 func convertProject(from project) *scm.Organization {

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -78,7 +78,7 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 		}
 	}
 	// Retrieve the list of groups attached to the project
-	groups, err := getProjectGroups(ctx, org, s, opts)
+	groups, err := getProjectGroups(ctx, org, s.client, opts)
 	if err != nil {
 		return false, res, err
 	}
@@ -102,10 +102,10 @@ func isRequestedUser(requested, name, slug string) bool {
 }
 
 // getProjectGroups returns the groups which have some permissions in the project
-func getProjectGroups(ctx context.Context, org string, os *organizationService, opts *scm.ListOptions) ([]*projGroup, error) {
+func getProjectGroups(ctx context.Context, org string, client *wrapper, opts *scm.ListOptions) ([]*projGroup, error) {
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/permissions/groups?%s", org, encodeListOptions(opts))
 	out := new(projGroups)
-	res, err := os.client.do(ctx, "GET", path, nil, out)
+	res, err := client.do(ctx, "GET", path, nil, out)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -143,7 +143,7 @@ func (s *organizationService) IsAdmin(ctx context.Context, org, user string) (bo
 		res.Page.Next = opts.Page + 1
 	}
 	for _, participant := range out.Values {
-		if (participant.User.Name == user || participant.User.Slug == user) && apiStringToPermission(participant.Permission) == scm.AdminPermission {
+		if isRequestedUser(user, participant.User.Name, participant.User.Slug) && apiStringToPermission(participant.Permission) == scm.AdminPermission {
 			return true, res, err
 		}
 	}

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -74,7 +74,7 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 	}
 	for _, participant := range out.Values {
 		if participant.User.Name == user || participant.User.Slug == user {
-			return true, res, err
+			return true, res, nil
 		}
 	}
 	// Retrieve the list of groups attached to the project
@@ -86,15 +86,15 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 		// Get list of users in a group
 		users, err := usersInGroups(ctx, pgroup.Group.Name, s, opts)
 		if err != nil {
-			return false, res, err
+			continue
 		}
 		for _, member := range users {
 			if member.Name == user || member.Slug == user {
-				return true, res, err
+				return true, res, nil
 			}
 		}
 	}
-	return false, res, err
+	return false, res, nil
 }
 
 // getProjectGroups returns the groups which have some permissions in the project

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -84,7 +84,7 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 	}
 	for _, pgroup := range groups {
 		// Get list of users in a group
-		users, err := usersInGroups(ctx, pgroup.Group.Name, s, opts)
+		users, err := usersInGroups(ctx, pgroup.Group.Name, s.client, opts)
 		if err != nil {
 			continue
 		}
@@ -117,10 +117,10 @@ func getProjectGroups(ctx context.Context, org string, os *organizationService, 
 }
 
 // usersInGroups returns the members/users in a group
-func usersInGroups(ctx context.Context, group string, os *organizationService, opts *scm.ListOptions) ([]*member, error) {
+func usersInGroups(ctx context.Context, group string, client *wrapper, opts *scm.ListOptions) ([]*member, error) {
 	path := fmt.Sprintf("rest/api/1.0/admin/groups/more-members?context=%s&%s", url.QueryEscape(group), encodeListOptions(opts))
 	out := new(members)
-	res, err := os.client.do(ctx, "GET", path, nil, out)
+	res, err := client.do(ctx, "GET", path, nil, out)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/driver/stash/org_test.go
+++ b/scm/driver/stash/org_test.go
@@ -7,7 +7,9 @@ package stash
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -181,6 +183,47 @@ func TestOrganizationIsAdmin(t *testing.T) {
 	}
 
 	if diff := cmp.Diff(got, false); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestIsMemberGroupWithSpaces(t *testing.T) {
+	defer gock.Off()
+
+	// Given a group named "my group" that requires URL encoding
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/some-project/permissions/users").
+		Reply(200).
+		Type("application/json").
+		File("testdata/org_members.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/some-project/permissions/groups").
+		Reply(200).
+		Type("application/json").
+		File("testdata/project_groups_with_spaces.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		AddMatcher(func(req *http.Request, _ *gock.Request) (bool, error) {
+			return strings.Contains(req.URL.RawQuery, "context=my+group"), nil
+		}).
+		Reply(200).
+		Type("application/json").
+		File("testdata/group_members.json")
+
+	client, _ := New("http://example.com:7990")
+
+	// When IsMember is called for a user in that group
+	got, _, err := client.Organizations.IsMember(context.Background(), "some-project", "jx-user")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Then the member is found
+	if diff := cmp.Diff(got, true); diff != "" {
 		t.Errorf("Unexpected Results")
 		t.Log(diff)
 	}

--- a/scm/driver/stash/org_test.go
+++ b/scm/driver/stash/org_test.go
@@ -153,6 +153,89 @@ func TestOrganizationIsMember(t *testing.T) {
 	}
 }
 
+func TestIsMemberContinuesOnGroupError(t *testing.T) {
+	defer gock.Off()
+
+	// Given a project with two groups where the first group lookup fails
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/some-project/permissions/users").
+		Reply(200).
+		Type("application/json").
+		File("testdata/org_members.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/some-project/permissions/groups").
+		Reply(200).
+		Type("application/json").
+		File("testdata/project_groups_two_groups.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		MatchParam("context", "failing-group").
+		Reply(500)
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		MatchParam("context", "good-group").
+		Reply(200).
+		Type("application/json").
+		File("testdata/group_members.json")
+
+	client, _ := New("http://example.com:7990")
+
+	// When IsMember is called for a user in the second group
+	got, _, err := client.Organizations.IsMember(context.Background(), "some-project", "jx-user")
+
+	// Then the member is found without error
+	if diff := cmp.Diff(true, got); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+
+	if diff := cmp.Diff(nil, err); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestIsMemberReturnsFalseWhenAllGroupsFail(t *testing.T) {
+	defer gock.Off()
+
+	// Given a project with one group whose lookup fails
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/some-project/permissions/users").
+		Reply(200).
+		Type("application/json").
+		File("testdata/org_members.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/some-project/permissions/groups").
+		Reply(200).
+		Type("application/json").
+		File("testdata/project_groups_one_failing.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		MatchParam("context", "failing-group").
+		Reply(500)
+
+	client, _ := New("http://example.com:7990")
+
+	// When IsMember is called for a user not in direct permissions
+	got, _, err := client.Organizations.IsMember(context.Background(), "some-project", "unknown-user")
+
+	// Then IsMember returns false without error
+	if diff := cmp.Diff(false, got); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+
+	if diff := cmp.Diff(nil, err); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
 func TestOrganizationIsAdmin(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -265,7 +265,7 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 		return false, resp, err
 	}
 	for k := range users {
-		if users[k].Name == user || users[k].Login == user {
+		if isRequestedUser(user, users[k].Name, users[k].Login) {
 			return true, resp, nil
 		}
 	}
@@ -282,7 +282,7 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 			continue
 		}
 		for _, member := range members {
-			if member.Name == user || member.Slug == user {
+			if isRequestedUser(user, member.Name, member.Slug) {
 				return true, resp, nil
 			}
 		}

--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -276,16 +276,8 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 	if err != nil {
 		return false, resp, err
 	}
-	for _, pgroup := range groups {
-		members, err := usersInGroups(ctx, pgroup.Group.Name, s.client, opts)
-		if err != nil {
-			continue
-		}
-		for _, member := range members {
-			if isRequestedUser(user, member.Name, member.Slug) {
-				return true, resp, nil
-			}
-		}
+	if isUserInGroups(ctx, user, groups, s.client, opts) {
+		return true, resp, nil
 	}
 
 	return false, resp, nil

--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -266,10 +266,43 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 	}
 	for k := range users {
 		if users[k].Name == user || users[k].Login == user {
-			return true, resp, err
+			return true, resp, nil
 		}
 	}
-	return false, resp, err
+
+	namespace, name := scm.Split(repo)
+	opts := &scm.ListOptions{Size: 1000}
+	groups, err := getRepoGroups(ctx, namespace, name, s.client, opts)
+	if err != nil {
+		return false, resp, err
+	}
+	for _, pgroup := range groups {
+		members, err := usersInGroups(ctx, pgroup.Group.Name, s.client, opts)
+		if err != nil {
+			continue
+		}
+		for _, member := range members {
+			if member.Name == user || member.Slug == user {
+				return true, resp, nil
+			}
+		}
+	}
+
+	return false, resp, nil
+}
+
+func getRepoGroups(ctx context.Context, namespace, name string, client *wrapper, opts *scm.ListOptions) ([]*projGroup, error) {
+	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/permissions/groups?%s", namespace, name, encodeListOptions(opts))
+	out := new(projGroups)
+	res, err := client.do(ctx, "GET", path, nil, out)
+	if err != nil {
+		return nil, err
+	}
+	if !out.pagination.LastPage.Bool {
+		res.Page.First = 1
+		res.Page.Next = opts.Page + 1
+	}
+	return out.Values, nil
 }
 
 func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, opts *scm.ListOptions) ([]scm.User, *scm.Response, error) {

--- a/scm/driver/stash/repo_test.go
+++ b/scm/driver/stash/repo_test.go
@@ -685,3 +685,99 @@ func TestRepositoryService_AddCollaborator(t *testing.T) {
 		t.Errorf("Expected collaborator to not already exist")
 	}
 }
+
+func TestIsCollaboratorViaGroup(t *testing.T) {
+	defer gock.Off()
+
+	// Given a repo where "jane" has no direct permissions but is in group "dev-team"
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/permissions/users").
+		Reply(200).
+		Type("application/json").
+		File("testdata/repo_collaborators_empty.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/permissions/groups").
+		Reply(200).
+		Type("application/json").
+		File("testdata/repo_groups.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		MatchParam("context", "ops-team").
+		Reply(200).
+		Type("application/json").
+		File("testdata/group_members_ops.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		MatchParam("context", "dev-team").
+		Reply(200).
+		Type("application/json").
+		File("testdata/group_members_jane.json")
+
+	client, _ := New("http://example.com:7990")
+
+	// When IsCollaborator is called for "jane"
+	got, _, err := client.Repositories.IsCollaborator(context.Background(), "PRJ/my-repo", "jane")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Then she is recognized as a collaborator
+	if diff := cmp.Diff(true, got); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+}
+
+func TestIsCollaboratorNotInGroup(t *testing.T) {
+	defer gock.Off()
+
+	// Given a repo where "bob" has no direct permissions and is not in any repo group
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/permissions/users").
+		Reply(200).
+		Type("application/json").
+		File("testdata/repo_collaborators_empty.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/projects/PRJ/repos/my-repo/permissions/groups").
+		Reply(200).
+		Type("application/json").
+		File("testdata/repo_groups.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		MatchParam("context", "ops-team").
+		Reply(200).
+		Type("application/json").
+		File("testdata/group_members_ops.json")
+
+	gock.New("http://example.com:7990").
+		Get("/rest/api/1.0/admin/groups/more-members").
+		MatchParam("context", "dev-team").
+		Reply(200).
+		Type("application/json").
+		File("testdata/group_members_jane.json")
+
+	client, _ := New("http://example.com:7990")
+
+	// When IsCollaborator is called for "bob"
+	got, _, err := client.Repositories.IsCollaborator(context.Background(), "PRJ/my-repo", "bob")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	// Then he is not recognized as a collaborator
+	if diff := cmp.Diff(false, got); diff != "" {
+		t.Errorf("Unexpected Results")
+		t.Log(diff)
+	}
+
+	if !gock.IsDone() {
+		t.Errorf("expected all gock mocks to be consumed")
+	}
+}

--- a/scm/driver/stash/testdata/group_members_jane.json
+++ b/scm/driver/stash/testdata/group_members_jane.json
@@ -1,0 +1,17 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "name": "jane",
+      "emailAddress": "jane@example.com",
+      "id": 201,
+      "displayName": "Jane Dev",
+      "active": true,
+      "slug": "jane",
+      "type": "NORMAL"
+    }
+  ],
+  "start": 0
+}

--- a/scm/driver/stash/testdata/group_members_ops.json
+++ b/scm/driver/stash/testdata/group_members_ops.json
@@ -1,0 +1,17 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "name": "ops-admin",
+      "emailAddress": "ops@example.com",
+      "id": 301,
+      "displayName": "Ops Admin",
+      "active": true,
+      "slug": "ops-admin",
+      "type": "NORMAL"
+    }
+  ],
+  "start": 0
+}

--- a/scm/driver/stash/testdata/project_groups_one_failing.json
+++ b/scm/driver/stash/testdata/project_groups_one_failing.json
@@ -1,0 +1,14 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "group": {
+        "name": "failing-group"
+      },
+      "permission": "PROJECT_WRITE"
+    }
+  ],
+  "start": 0
+}

--- a/scm/driver/stash/testdata/project_groups_two_groups.json
+++ b/scm/driver/stash/testdata/project_groups_two_groups.json
@@ -1,0 +1,20 @@
+{
+  "size": 2,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "group": {
+        "name": "failing-group"
+      },
+      "permission": "PROJECT_WRITE"
+    },
+    {
+      "group": {
+        "name": "good-group"
+      },
+      "permission": "PROJECT_WRITE"
+    }
+  ],
+  "start": 0
+}

--- a/scm/driver/stash/testdata/project_groups_with_spaces.json
+++ b/scm/driver/stash/testdata/project_groups_with_spaces.json
@@ -1,0 +1,14 @@
+{
+  "size": 1,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "group": {
+        "name": "my group"
+      },
+      "permission": "PROJECT_WRITE"
+    }
+  ],
+  "start": 0
+}

--- a/scm/driver/stash/testdata/repo_collaborators_empty.json
+++ b/scm/driver/stash/testdata/repo_collaborators_empty.json
@@ -1,0 +1,7 @@
+{
+  "size": 0,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [],
+  "start": 0
+}

--- a/scm/driver/stash/testdata/repo_groups.json
+++ b/scm/driver/stash/testdata/repo_groups.json
@@ -1,0 +1,20 @@
+{
+  "size": 2,
+  "limit": 25,
+  "isLastPage": true,
+  "values": [
+    {
+      "group": {
+        "name": "ops-team"
+      },
+      "permission": "REPO_READ"
+    },
+    {
+      "group": {
+        "name": "dev-team"
+      },
+      "permission": "REPO_WRITE"
+    }
+  ],
+  "start": 0
+}


### PR DESCRIPTION
#### Summary

Fixes #522 group-based permission checks for Bitbucket Server. `IsMember()` already checked groups but failed to URL-encode group names with spaces and aborted on the first group lookup error. `IsCollaborator()` only checked direct user permissions, missing group-based access entirely.

 #### Changes

- URL-encode group names in member lookups to support spaces
- Continue group iteration on individual lookup failures instead of failing early
- Check repository-level group permissions in `IsCollaborator()`

Should fix #310 as well.