### PR TITLE
fix(gitea): use pointer for EditPullRequestOption.Body

### DIFF
--- a/scm/driver/gitea/pr.go
+++ b/scm/driver/gitea/pr.go
@@ -97,7 +97,7 @@ func (s *pullService) Update(ctx context.Context, repo string, number int, input
 	namespace, name := scm.Split(repo)
 	in := gitea.EditPullRequestOption{
 		Title: input.Title,
-		Body:  input.Body,
+		Body:  &input.Body,
 		Base:  input.Base,
 	}
 	out, resp, err := s.client.GiteaClient.EditPullRequest(namespace, name, int64(number), in)


### PR DESCRIPTION
The gitea SDK changed `EditPullRequestOption.Body` from `string` to `*string` in v0.22.0 for proper PATCH semantics (`nil` = don't update, pointer = set value). This breaks compilation when bumping the SDK past v0.21.0.

Unblocks #518 (dependabot bump of gitea SDK to v0.22.1).

Also unblocks downstream consumers like [tektoncd/pipeline#9342](https://github.com/tektoncd/pipeline/pull/9342) which can't bump the gitea SDK until go-scm is compatible.