### PR TITLE
fix(gitlab): do not map diff_refs.base_sha to PullRequest.Base.Sha

### DIFF
--- a/scm/driver/gitlab/pr.go
+++ b/scm/driver/gitlab/pr.go
@@ -319,7 +319,26 @@ type pr struct {
 	Created         time.Time `json:"created_at"`
 	Updated         time.Time `json:"updated_at"`
 	Closed          time.Time
-	DiffRefs        struct {
+	// DiffRefs is only populated by GitLab on the single-MR endpoint
+	// (GET /merge_requests/:iid); the list endpoint omits it entirely.
+	//
+	// IMPORTANT: DiffRefs.BaseSHA must NOT be mapped to scm.PullRequest.Base.Sha.
+	// They look like they mean the same thing but they do not:
+	//   - GitLab's diff_refs.base_sha is the *merge-base* (common ancestor of
+	//     source and target at the time the MR's diff was last computed).
+	//   - GitHub's pull_request.base.sha — and therefore scm.PullRequest.Base.Sha —
+	//     is the *HEAD of the base branch* at the time of the PR's last sync.
+	// Consumers (e.g. lighthouse's step-git-merge / PULL_BASE_SHA) treat
+	// Base.Sha as "the commit to merge the PR head into", which is the
+	// branch tip, not the merge-base. Using diff_refs.base_sha there can
+	// merge the PR onto a stale commit.
+	//
+	// Consequence: scm.PullRequest.Base.Sha is left empty by the GitLab driver
+	// on both Find and List. Callers that need the base-branch HEAD (rare —
+	// at the time of writing only lighthouse keeper actually relies on it,
+	// and it can compute it per-subpool rather than per-PR) must resolve it
+	// themselves via Git.FindBranch(target_project, target_branch).
+	DiffRefs struct {
 		BaseSHA string `json:"base_sha"`
 		HeadSHA string `json:"head_sha"`
 	} `json:"diff_refs"`
@@ -429,8 +448,12 @@ func (s *pullService) convertPullRequest(ctx context.Context, from *pr) (*scm.Pu
 			Repo: *headRepo,
 		},
 		Base: scm.PullRequestBranch{
-			Ref:  from.TargetBranch,
-			Sha:  from.DiffRefs.BaseSHA,
+			Ref: from.TargetBranch,
+			// Sha is intentionally left empty. GitLab's diff_refs.base_sha is
+			// the merge-base, not the base-branch HEAD that GitHub's API
+			// (and scm.PullRequest.Base.Sha consumers) expect — see the
+			// comment on the DiffRefs field. Callers that need it must
+			// resolve via Git.FindBranch.
 			Repo: *baseRepo,
 		},
 		Created: from.Created,

--- a/scm/driver/gitlab/pr_test.go
+++ b/scm/driver/gitlab/pr_test.go
@@ -65,6 +65,43 @@ func TestPullFind(t *testing.T) {
 	t.Run("Rate", testRate(res))
 }
 
+// TestPullFind_BaseShaNotMappedFromDiffRefs asserts that scm.PullRequest.Base.Sha
+// is NOT populated from GitLab's diff_refs.base_sha — see the comment on the
+// `pr` struct's DiffRefs field for why these are semantically different
+// (merge-base vs. base-branch HEAD). Regression guard: if a future change
+// re-maps that field, this test catches it.
+func TestPullFind_BaseShaNotMappedFromDiffRefs(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/32732").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/repo.json")
+	gock.New("https://gitlab.com").
+		Get("/api/v4/projects/diaspora/diaspora/merge_requests/1347").
+		Reply(200).
+		Type("application/json").
+		SetHeaders(mockHeaders).
+		File("testdata/merge.json") // contains diff_refs.base_sha = "9c5dc8c4..."
+
+	client := NewDefault()
+	got, _, err := client.PullRequests.Find(context.Background(), "diaspora/diaspora", 1347)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if got.Base.Sha != "" {
+		t.Errorf("Base.Sha should be empty on GitLab (do NOT map from diff_refs.base_sha — merge-base, not branch HEAD); got %q", got.Base.Sha)
+	}
+}
+
 func TestPullList(t *testing.T) {
 	defer gock.Off()
 

--- a/scm/driver/gitlab/testdata/merge.json
+++ b/scm/driver/gitlab/testdata/merge.json
@@ -36,6 +36,11 @@
     "merge_status": "can_be_merged",
     "sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
     "merge_commit_sha": null,
+    "diff_refs": {
+        "base_sha": "9c5dc8c4123abcdef0123456789abcdef0123456",
+        "head_sha": "12d65c8dd2b2676fa3ac47d955accc085a37a9c1",
+        "start_sha": "9c5dc8c4123abcdef0123456789abcdef0123456"
+    },
     "user_notes_count": 1,
     "approvals_before_merge": null,
     "discussion_locked": null,

--- a/scm/driver/gitlab/testdata/pr_create.json.golden
+++ b/scm/driver/gitlab/testdata/pr_create.json.golden
@@ -9,7 +9,6 @@
   "Target": "master",
   "Base": {
     "Ref": "master",
-    "Sha": "c380d3acebd181f13629a25d2e2acca46ffe1e00",
     "Repo": {
       "ID": "32732",
       "Namespace": "diaspora",


### PR DESCRIPTION
GitLab's diff_refs.base_sha is the merge-base (common ancestor at last diff computation), not the base-branch HEAD that scm.PullRequest.Base.Sha consumers expect for parity with GitHub. Mapping it caused PRs on GitLab to surface a stale or empty SHA depending on the endpoint:

- Single-MR (Find): merge-base, semantically wrong for callers like lighthouse step-git-merge that need the branch tip to merge into.
- List: GitLab omits diff_refs entirely, leaving Base.Sha empty and breaking downstream PULL_REFS construction.

Leave Base.Sha empty on both Find and List with a clear comment on the DiffRefs field. Callers that need the base-branch HEAD must resolve via Git.FindBranch — adding it unconditionally to Find would pay an extra request per call for the benefit of a single known consumer.

Adds a regression test and stops asserting the wrong value in existing fixtures.