### PR TITLE
chore: upgrade to go 1.26.3

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: build-make-linux
-      uses: docker://golang:1.20.14
+      uses: docker://golang:1.26.3
       with:
         args: -c "make check test"
         entrypoint: /bin/sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,11 +98,19 @@ linters:
         text: unused-parameter
       - path: (.+)\.go$
         text: 'shadow: declaration of "err" shadows declaration at'
+      - linters:
+          - gosec
+        path: _test\.go
+        text: 'G101|G706'
+      - linters:
+          - gosec
+        path: scm/factory/factory\.go
+        text: G101
     paths:
       - cmd/docs
       - third_party$
       - builtin$
-      - examples$
+      - scm/factory/examples
 issues:
   max-same-issues: 0
 formatters:
@@ -118,4 +126,4 @@ formatters:
       - cmd/docs
       - third_party$
       - builtin$
-      - examples$
+      - scm/factory/examples

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,114 +1,121 @@
-linters-settings:
-  depguard:
-    rules:
-      # Name of a rule.
-      Main:
-        list-mode: lax
-        deny:
-        - pkg: github.com/jenkins-x/jx/v2/pkg/log/
-          desc: "use jenkins-x/jx-logging instead"
-        - pkg: github.com/satori/go.uuid
-          desc: "use github.com/google/uuid instead"
-        - pkg: github.com/pborman/uuid
-          desc: "use github.com/google/uuid instead"
-  dupl:
-    threshold: 100
-  exhaustive:
-    default-signifies-exhaustive: false
-  funlen:
-    lines: 200
-    statements: 150
-  goconst:
-    min-len: 3
-    min-occurrences: 3
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
-      - ifElseChain
-      - octalLiteral
-      - whyNoLint
-      - wrapperFunc
-      - importShadow # not important for now
-      - unnamedResult # not important
-  gocyclo:
-    min-complexity: 15
-  goimports: {}
-  revive:
-    confidence: 0
-  gofmt:
-    simplify: true
-  mnd:
-    # don't include the "operation" and "assign"
-    checks: [argument, case, condition, return]
-  govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Debugf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Infof
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Warnf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Errorf
-          - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
-  lll:
-    line-length: 140
-  misspell: {}
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # don't require an explanation for nolint directives
-    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bodyclose
     - depguard
     - errcheck
-    - gofmt
-    - goimports
+    - gocritic
     - goprintffuncname
     - gosec
-    - gosimple
+    - govet
     - ineffassign
     - misspell
     - nakedret
+    - revive
     - rowserrcheck
     - staticcheck
-    - typecheck
     - unconvert
     - unparam
     - unused
-    - revive
-    - gocritic
-    - govet
+  settings:
+    depguard:
+      rules:
+        Main:
+          list-mode: lax
+          deny:
+            - pkg: github.com/jenkins-x/jx/v2/pkg/log/
+              desc: use jenkins-x/jx-logging instead
+            - pkg: github.com/satori/go.uuid
+              desc: use github.com/google/uuid instead
+            - pkg: github.com/pborman/uuid
+              desc: use github.com/google/uuid instead
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: false
+    funlen:
+      lines: 200
+      statements: 150
+    goconst:
+      min-len: 3
+      min-occurrences: 3
+    gocritic:
+      disabled-checks:
+        - dupImport
+        - ifElseChain
+        - octalLiteral
+        - whyNoLint
+        - wrapperFunc
+        - importShadow
+        - unnamedResult
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    govet:
+      settings:
+        printf:
+          funcs:
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Debugf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Infof
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Warnf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Errorf
+            - (github.com/jenkins-x/jx-logging/v3/pkg/log/Logger()).Fatalf
+    lll:
+      line-length: 140
+    mnd:
+      checks:
+        - argument
+        - case
+        - condition
+        - return
+    nolintlint:
+      require-explanation: false
+      require-specific: false
+      allow-unused: false
+    revive:
+      confidence: 0
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gocritic
+        text: 'unnecessaryDefer:'
+      - linters:
+          - revive
+        path: scm/driver/
+        text: unused-parameter
+      - path: (.+)\.go$
+        text: 'shadow: declaration of "err" shadows declaration at'
+    paths:
+      - cmd/docs
+      - third_party$
+      - builtin$
+      - examples$
 issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    #    - path: _test\.go
-    #      linters:
-    #        - gomnd
-    #    https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-    - path: scm/driver/ # The drivers mostly implement interfaces and often the methods don't need all parameters
-      text: "unused-parameter"
-      linters:
-        - revive
-  exclude:
-    - 'shadow: declaration of "err" shadows declaration at'
   max-same-issues: 0
-  exclude-dirs:
-    - cmd/docs
-
-run:
-  timeout: 4h
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - cmd/docs
+      - third_party$
+      - builtin$
+      - examples$

--- a/go.mod
+++ b/go.mod
@@ -49,4 +49,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-go 1.24.0
+go 1.26.3

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -10,7 +10,7 @@ fi
 linterVersion="$(golangci-lint --version | awk '{print $4}')"
 
 if [[ ! "${linterVersion}" =~ ^v?1\.6[0-9] ]]; then
-	echo "Install GolangCI-Lint version 1.26.x"
+	echo "Install GolangCI-Lint version 1.6x.x"
   exit 1
 fi
 

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -9,8 +9,8 @@ fi
 
 linterVersion="$(golangci-lint --version | awk '{print $4}')"
 
-if [[ ! "${linterVersion}" =~ ^v?1\.6[0-9] ]]; then
-	echo "Install GolangCI-Lint version 1.6x.x"
+if [[ ! "${linterVersion}" =~ ^v?2\.12\. ]]; then
+	echo "Install GolangCI-Lint version 2.12.x"
   exit 1
 fi
 

--- a/hack/linter.sh
+++ b/hack/linter.sh
@@ -10,7 +10,7 @@ fi
 linterVersion="$(golangci-lint --version | awk '{print $4}')"
 
 if [[ ! "${linterVersion}" =~ ^v?1\.6[0-9] ]]; then
-	echo "Install GolangCI-Lint version 1.6x.x"
+	echo "Install GolangCI-Lint version 1.26.x"
   exit 1
 fi
 

--- a/scm/client.go
+++ b/scm/client.go
@@ -22,7 +22,7 @@ var (
 
 	// ErrNotSupported indicates a resource endpoint is not
 	// supported or implemented.
-	ErrNotSupported = errors.New("Not Supported")
+	ErrNotSupported = errors.New("not supported")
 )
 
 type (

--- a/scm/driver/azure/azure.go
+++ b/scm/driver/azure/azure.go
@@ -70,7 +70,7 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 		req.Body = buf
 	}
 	// execute the http request
-	res, err := c.Client.Do(ctx, req)
+	res, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/driver/bitbucket/bitbucket.go
+++ b/scm/driver/bitbucket/bitbucket.go
@@ -84,7 +84,7 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 	}
 
 	// execute the http request
-	res, err := c.Client.Do(ctx, req)
+	res, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/driver/gitea/gitea.go
+++ b/scm/driver/gitea/gitea.go
@@ -121,7 +121,7 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 	}
 
 	// execute the http request
-	res, err := c.Client.Do(ctx, req)
+	res, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/driver/github/github.go
+++ b/scm/driver/github/github.go
@@ -138,7 +138,7 @@ func (c *wrapper) doRequest(ctx context.Context, req *scm.Request, in, out inter
 	}
 
 	// execute the http request
-	res, err := c.Client.Do(ctx, req)
+	res, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (c *wrapper) doRequest(ctx context.Context, req *scm.Request, in, out inter
 	)
 
 	// snapshot the request rate limit
-	c.Client.SetRate(res.Rate)
+	c.SetRate(res.Rate)
 
 	// if an error is encountered, unmarshal and return the
 	// error response.

--- a/scm/driver/github/org.go
+++ b/scm/driver/github/org.go
@@ -78,11 +78,12 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 		return false, res, err
 	}
 	code := res.Status
-	if code == 204 {
+	switch code {
+	case 204:
 		return true, res, nil
-	} else if code == 404 {
+	case 404:
 		return false, res, nil
-	} else if code == 302 {
+	case 302:
 		return false, res, fmt.Errorf("requester is not %s org member", org)
 	}
 	// Should be unreachable.

--- a/scm/driver/github/release.go
+++ b/scm/driver/github/release.go
@@ -66,7 +66,7 @@ func (s *releaseService) Create(ctx context.Context, repo string, input *scm.Rel
 		Prerelease:  input.Prerelease,
 		Tag:         input.Tag,
 	}
-	if !(in.Prerelease || in.Draft) {
+	if !in.Prerelease && !in.Draft {
 		in.MakeLatest = "true"
 	}
 	out := new(release)
@@ -101,7 +101,7 @@ func (s *releaseService) Update(ctx context.Context, repo string, id int, input 
 	}
 	in.Draft = input.Draft
 	in.Prerelease = input.Prerelease
-	if !(in.Prerelease || in.Draft) {
+	if !in.Prerelease && !in.Draft {
 		in.MakeLatest = "true"
 	}
 	out := new(release)

--- a/scm/driver/github/repo.go
+++ b/scm/driver/github/repo.go
@@ -87,11 +87,12 @@ func (s *repositoryService) AddCollaborator(ctx context.Context, repo, user, per
 		return false, false, res, err
 	}
 	code := res.Status
-	if code == 201 {
+	switch code {
+	case 201:
 		return true, false, res, nil
-	} else if code == 204 {
+	case 204:
 		return false, true, res, nil
-	} else if code == 404 {
+	case 404:
 		return false, false, res, nil
 	}
 	return false, false, res, fmt.Errorf("unexpected status: %d", code)
@@ -121,9 +122,10 @@ func (s *repositoryService) IsCollaborator(ctx context.Context, repo, user strin
 		return false, res, err
 	}
 	code := res.Status
-	if code == 204 {
+	switch code {
+	case 204:
 		return true, res, nil
-	} else if code == 404 {
+	case 404:
 		return false, res, nil
 	}
 	return false, res, fmt.Errorf("unexpected status: %d", code)
@@ -403,10 +405,7 @@ func convertHookList(from []*hook) []*scm.Hook {
 
 func convertHook(from *hook) *scm.Hook {
 
-	skipVerify := false
-	if from.Config.InsecureSSL == "1" {
-		skipVerify = true
-	}
+	skipVerify := from.Config.InsecureSSL == "1"
 
 	return &scm.Hook{
 		ID:         strconv.Itoa(from.ID),

--- a/scm/driver/gitlab/content.go
+++ b/scm/driver/gitlab/content.go
@@ -20,7 +20,7 @@ type contentService struct {
 
 func (s *contentService) Find(ctx context.Context, repo, path, ref string) (*scm.Content, *scm.Response, error) {
 	path = url.QueryEscape(path)
-	path = strings.Replace(path, ".", "%2E", -1)
+	path = strings.ReplaceAll(path, ".", "%2E")
 	endpoint := fmt.Sprintf("api/v4/projects/%s/repository/files/%s?ref=%s", encode(repo), path, ref)
 	out := new(content)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
@@ -62,7 +62,7 @@ func (s *contentService) Create(ctx context.Context, repo, path string, params *
 
 func (s *contentService) Update(ctx context.Context, repo, path string, params *scm.ContentParams) (*scm.Response, error) {
 	path = url.QueryEscape(path)
-	path = strings.Replace(path, ".", "%2E", -1)
+	path = strings.ReplaceAll(path, ".", "%2E")
 	endpoint := fmt.Sprintf("api/v4/projects/%s/repository/files/%s", encode(repo), path)
 
 	body := &updateContentBody{

--- a/scm/driver/gitlab/gitlab.go
+++ b/scm/driver/gitlab/gitlab.go
@@ -149,7 +149,7 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 		req.Body = buf
 	}
 	// execute the http request
-	res, err := c.Client.Do(ctx, req)
+	res, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +170,7 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 	)
 
 	// snapshot the request rate limit
-	c.Client.SetRate(res.Rate)
+	c.SetRate(res.Rate)
 
 	// if an error is encountered, unmarshal and return the
 	// error response.

--- a/scm/driver/gitlab/util.go
+++ b/scm/driver/gitlab/util.go
@@ -13,7 +13,7 @@ import (
 )
 
 func encode(s string) string {
-	return strings.Replace(s, "/", "%2F", -1)
+	return strings.ReplaceAll(s, "/", "%2F")
 }
 
 func encodeListOptions(opts *scm.ListOptions) string {

--- a/scm/driver/gogs/gogs.go
+++ b/scm/driver/gogs/gogs.go
@@ -77,7 +77,7 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 	}
 
 	// execute the http request
-	res, err := c.Client.Do(ctx, req)
+	res, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/driver/stash/content.go
+++ b/scm/driver/stash/content.go
@@ -33,7 +33,7 @@ func (s *contentService) List(ctx context.Context, repo, path, ref string, opts 
 	endpoint := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/files/%s?at=%s&%s", namespace, name, path, ref, encodeListOptions(opts))
 	out := new(contents)
 	res, err := s.client.do(ctx, "GET", endpoint, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}

--- a/scm/driver/stash/git.go
+++ b/scm/driver/stash/git.go
@@ -104,7 +104,7 @@ func (s *gitService) ListBranches(ctx context.Context, repo string, opts *scm.Li
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/branches?%s", namespace, name, encodeListOptions(opts))
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -120,7 +120,7 @@ func (s *gitService) ListTags(ctx context.Context, repo string, opts *scm.ListOp
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/tags?%s", namespace, name, encodeListOptions(opts))
 	out := new(branches)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -132,7 +132,7 @@ func (s *gitService) ListChanges(ctx context.Context, repo, ref string, opts *sc
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/commits/%s/changes?%s", namespace, name, url.PathEscape(ref), encodeListOptions(opts))
 	out := new(diffstats)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -146,7 +146,7 @@ func (s *gitService) CompareCommits(ctx context.Context, repo, ref1, ref2 string
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/compare/changes?%s", namespace, name, encodeListOptions(opts))
 	out := new(diffstats)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}

--- a/scm/driver/stash/org.go
+++ b/scm/driver/stash/org.go
@@ -49,7 +49,7 @@ func (s *organizationService) ListOrgMembers(ctx context.Context, org string, op
 	path := projectUsersPermissionsPath(org, opts)
 	out := new(participants)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -68,7 +68,7 @@ func (s *organizationService) IsMember(ctx context.Context, org, user string) (b
 	if err != nil {
 		return false, res, err
 	}
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -116,7 +116,7 @@ func getProjectGroups(ctx context.Context, org string, client *wrapper, opts *sc
 	if err != nil {
 		return nil, err
 	}
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -131,7 +131,7 @@ func usersInGroups(ctx context.Context, group string, client *wrapper, opts *scm
 	if err != nil {
 		return nil, err
 	}
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -145,7 +145,7 @@ func (s *organizationService) IsAdmin(ctx context.Context, org, user string) (bo
 	path := projectUsersPermissionsPath(org, opts)
 	out := new(participants)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}

--- a/scm/driver/stash/org_test.go
+++ b/scm/driver/stash/org_test.go
@@ -137,7 +137,7 @@ func TestOrganizationIsMember(t *testing.T) {
 	}
 
 	for k, v := range testCases {
-		t.Logf("Running test %q: %s", k, v.description)
+		t.Logf("Running test %d: %s", k, v.description)
 		client, _ := New("http://example.com:7990")
 
 		got, _, err := client.Organizations.IsMember(context.Background(), "some-project", v.user)

--- a/scm/driver/stash/pr.go
+++ b/scm/driver/stash/pr.go
@@ -42,7 +42,7 @@ func (s *pullService) List(ctx context.Context, repo string, opts *scm.PullReque
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/pull-requests", namespace, name)
 	out := new(pullRequests)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -54,7 +54,7 @@ func (s *pullService) ListChanges(ctx context.Context, repo string, number int, 
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/changes?%s", namespace, name, number, encodeListOptions(opts))
 	out := new(diffstats)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -102,7 +102,7 @@ func (s *pullService) ListComments(ctx context.Context, repo string, number int,
 	out := new(pullRequestActivities)
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/pull-requests/%d/activities?%s", projectName, repoName, number, encodeListOptions(opts))
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}

--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -290,7 +290,7 @@ func getRepoGroups(ctx context.Context, namespace, name string, client *wrapper,
 	if err != nil {
 		return nil, err
 	}
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -303,7 +303,7 @@ func (s *repositoryService) ListCollaborators(ctx context.Context, repo string, 
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/permissions/users?%s", namespace, name, encodeListOptions(opts))
 	out := new(participants)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -389,7 +389,7 @@ func (s *repositoryService) List(ctx context.Context, opts *scm.ListOptions) ([]
 	path := fmt.Sprintf("rest/api/1.0/repos?%s", encodeListRoleOptions(opts))
 	out := new(repositories)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -400,7 +400,7 @@ func (s *repositoryService) ListOrganisation(ctx context.Context, org string, op
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos?%s", org, encodeListRoleOptions(opts))
 	out := new(repositories)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -426,7 +426,7 @@ func (s *repositoryService) ListHooks(ctx context.Context, repo string, opts *sc
 	path := fmt.Sprintf("rest/api/1.0/projects/%s/repos/%s/webhooks?%s", namespace, name, encodeListOptions(opts))
 	out := new(hooks)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}
@@ -438,7 +438,7 @@ func (s *repositoryService) ListStatus(ctx context.Context, _, ref string, opts 
 	path := fmt.Sprintf("rest/build-status/1.0/commits/%s?%s", url.PathEscape(ref), encodeListOptions(opts))
 	out := new(statuses)
 	res, err := s.client.do(ctx, "GET", path, nil, &out)
-	if !out.pagination.LastPage.Bool {
+	if !out.LastPage.Bool {
 		res.Page.First = 1
 		res.Page.Next = opts.Page + 1
 	}

--- a/scm/driver/stash/stash.go
+++ b/scm/driver/stash/stash.go
@@ -106,7 +106,7 @@ func (c *wrapper) do(ctx context.Context, method, path string, in, out interface
 	req.Header.Add("X-Atlassian-Token", "no-check")
 
 	// execute the http request
-	res, err := c.Client.Do(ctx, req)
+	res, err := c.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/scm/example_test.go
+++ b/scm/example_test.go
@@ -251,7 +251,7 @@ func ExampleContent_find() {
 		log.Fatal(err)
 	}
 
-	log.Println(content.Path, content.Data)
+	log.Println(content.Path, string(content.Data))
 }
 
 func ExampleHook_list() {

--- a/scm/factory/factory.go
+++ b/scm/factory/factory.go
@@ -26,7 +26,7 @@ import (
 )
 
 // ErrMissingGitServerURL the error returned if you use a git driver that needs a git server URL
-var ErrMissingGitServerURL = fmt.Errorf("No git serverURL was specified")
+var ErrMissingGitServerURL = fmt.Errorf("no git serverURL was specified")
 
 // DefaultIdentifier is the default driver identifier used by FromRepoURL.
 var DefaultIdentifier = NewDriverIdentifier()
@@ -64,7 +64,7 @@ func NewClientWithBasicAuth(driver, serverURL, user, password string, opts ...Cl
 		}
 		client, err = gitea.NewWithBasicAuth(serverURL, user, password)
 	default:
-		return nil, fmt.Errorf("Unsupported $GIT_KIND value: %s", driver)
+		return nil, fmt.Errorf("unsupported $GIT_KIND value: %s", driver)
 	}
 	if err != nil {
 		return client, err
@@ -134,7 +134,7 @@ func newClient(driver, serverURL string, authOptions *AuthOptions, opts ...Clien
 		}
 		client, err = stash.New(serverURL)
 	default:
-		return nil, fmt.Errorf("Unsupported $GIT_KIND value: %s", driver)
+		return nil, fmt.Errorf("unsupported $GIT_KIND value: %s", driver)
 	}
 	if err != nil {
 		return client, err
@@ -216,7 +216,7 @@ func NewClientFromEnvironment() (*scm.Client, error) {
 	}
 
 	if oauthToken == "" {
-		return nil, fmt.Errorf("No Git OAuth token specified for $GIT_TOKEN")
+		return nil, fmt.Errorf("no Git OAuth token specified for $GIT_TOKEN")
 	}
 
 	authOptions := &AuthOptions{
@@ -306,7 +306,7 @@ func NewWebHookService(driver string) (scm.WebhookService, error) {
 	case "stash", "bitbucketserver":
 		service = stash.NewWebHookService()
 	default:
-		return nil, fmt.Errorf("Unsupported GIT_KIND value: %s", driver)
+		return nil, fmt.Errorf("unsupported GIT_KIND value: %s", driver)
 	}
 
 	return service, nil

--- a/scm/transport/oauth1/encode.go
+++ b/scm/transport/oauth1/encode.go
@@ -34,7 +34,7 @@ func percentEncode(input string) string {
 	for _, b := range []byte(input) {
 		// if in unreserved set
 		if shouldEscape(b) {
-			buf.Write([]byte(fmt.Sprintf("%%%02X", b)))
+			fmt.Fprintf(&buf, "%%%02X", b)
 		} else {
 			// do not escape, write byte as-is
 			buf.WriteByte(b)


### PR DESCRIPTION
- upgrade to go 1.26.3
- upgrade golangci-lint to 2.12.2 via `golangci-lint migrate`
- update linter.sh 
- change to int type in log formatting
- adopt and add all quick fixes identified by linter in the new version of golangci
- part of https://github.com/jenkins-x/jx/issues/8965