### PR TITLE
fix(Bitbucket): updated URL for retrieving a list of workspaces

### DIFF
--- a/scm/driver/bitbucket/org.go
+++ b/scm/driver/bitbucket/org.go
@@ -68,7 +68,7 @@ func (s *organizationService) Find(ctx context.Context, name string) (*scm.Organ
 }
 
 func (s *organizationService) List(ctx context.Context, opts *scm.ListOptions) ([]*scm.Organization, *scm.Response, error) {
-	path := fmt.Sprintf("2.0/workspaces?%s", encodeListRoleOptions(opts))
+	path := fmt.Sprintf("2.0/user/workspaces?%s", encodeListRoleOptions(opts))
 	out := new(organizationList)
 	res, err := s.client.do(ctx, "GET", path, nil, out)
 	if err != nil {

--- a/scm/driver/bitbucket/org_test.go
+++ b/scm/driver/bitbucket/org_test.go
@@ -43,7 +43,7 @@ func TestOrganizationFind(t *testing.T) {
 func TestOrganizationList(t *testing.T) {
 	defer gock.Off()
 	gock.New("https://api.bitbucket.org").
-		Get("/2.0/workspaces").
+		Get("/2.0/user/workspaces").
 		MatchParam("pagelen", "30").
 		MatchParam("page", "1").
 		Reply(200).


### PR DESCRIPTION
On August 28th, 2025, Atlassian announced they were deprecating cross-workspace APIs and with that removing the endpoint to get available workspaces. This endpoint was moved behind the user endpoints. E.g. "/2.0/workspaces -> /2.0/user/workspaces". The deprecation went into affect on February 27th, 2026.

This PR updates the endpoint for listing the available workspaces and also updates the test to use the proper endpoint.

I am not a Go developer so I did not add a regression test. If wanted I can attempt to add on, but it will need to be after this gets merged in as this issue is preventing me from implementing JayeX for my company.


https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-2770