### PR TITLE
feat: natively support dynamic tokens

### DIFF
--- a/scm/driver/gitea/gitea.go
+++ b/scm/driver/gitea/gitea.go
@@ -17,6 +17,7 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/jenkins-x/go-scm/scm"
+	"github.com/jenkins-x/go-scm/scm/transport"
 )
 
 // NewWebHookService creates a new instance of the webhook service without the rest of the client
@@ -31,6 +32,35 @@ func New(uri string) (*scm.Client, error) {
 
 // NewWithToken returns a new Gitea API client with the token set.
 func NewWithToken(uri, token string) (*scm.Client, error) {
+	return newClient(uri, gitea.SetToken(token))
+}
+
+// NewWithBasicAuth returns a new Gitea API client with the basic auth set.
+func NewWithBasicAuth(uri, user, password string) (*scm.Client, error) {
+	return newClient(uri, gitea.SetBasicAuth(user, password))
+}
+
+// NewWithTokenSource returns a new Gitea API client that resolves its token
+// from source on every request, so a token that expires part way through the
+// life of the client is replaced without the client having to be rebuilt.
+func NewWithTokenSource(uri string, source scm.TokenSource) (*scm.Client, error) {
+	httpClient := &http.Client{
+		Transport: &transport.Auth{
+			Source:     source,
+			Credential: transport.SchemeCredential("token"),
+		},
+	}
+	client, err := newClient(uri, gitea.SetHTTPClient(httpClient))
+	if err != nil {
+		return nil, err
+	}
+	// The Gitea SDK serves most of this driver from its own http.Client, but a
+	// handful of calls go through scm.Client, so both need the transport.
+	client.Client = httpClient
+	return client, nil
+}
+
+func newClient(uri string, opts ...gitea.ClientOption) (*scm.Client, error) {
 	base, err := url.Parse(uri)
 	if err != nil {
 		return nil, err
@@ -39,7 +69,7 @@ func NewWithToken(uri, token string) (*scm.Client, error) {
 		base.Path += "/"
 	}
 	client := &wrapper{Client: new(scm.Client)}
-	client.GiteaClient, err = gitea.NewClient(base.String(), gitea.SetToken(token))
+	client.GiteaClient, err = gitea.NewClient(base.String(), opts...)
 
 	if err != nil {
 		return nil, err
@@ -56,37 +86,6 @@ func NewWithToken(uri, token string) (*scm.Client, error) {
 	client.Repositories = &repositoryService{client}
 	client.Reviews = &reviewService{client}
 	client.Releases = &releaseService{client}
-	client.Users = &userService{client}
-	client.Webhooks = &webhookService{client}
-	return client.Client, nil
-}
-
-// NewWithBasicAuth returns a new Gitea API client with the basic auth set.
-func NewWithBasicAuth(uri, user, password string) (*scm.Client, error) {
-	base, err := url.Parse(uri)
-	if err != nil {
-		return nil, err
-	}
-	if !strings.HasSuffix(base.Path, "/") {
-		base.Path += "/"
-	}
-	client := &wrapper{Client: new(scm.Client)}
-	client.GiteaClient, err = gitea.NewClient(base.String(), gitea.SetBasicAuth(user, password))
-
-	if err != nil {
-		return nil, err
-	}
-	client.BaseURL = base
-	// initialize services
-	client.Driver = scm.DriverGitea
-	client.Contents = &contentService{client}
-	client.Git = &gitService{client}
-	client.Issues = &issueService{client}
-	client.Milestones = &milestoneService{client}
-	client.Organizations = &organizationService{client}
-	client.PullRequests = &pullService{&issueService{client}}
-	client.Repositories = &repositoryService{client}
-	client.Reviews = &reviewService{client}
 	client.Users = &userService{client}
 	client.Webhooks = &webhookService{client}
 	return client.Client, nil

--- a/scm/driver/github/integration/github_test.go
+++ b/scm/driver/github/integration/github_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/github"
 	"github.com/jenkins-x/go-scm/scm/transport"
 )
@@ -21,8 +22,9 @@ func TestGitHub(t *testing.T) {
 
 	client := github.NewDefault()
 	client.Client = &http.Client{
-		Transport: &transport.BearerToken{
-			Token: os.Getenv("GITHUB_TOKEN"),
+		Transport: &transport.Auth{
+			Source:     scm.StaticTokenSource(os.Getenv("GITHUB_TOKEN")),
+			Credential: transport.SchemeCredential("Bearer"),
 		},
 	}
 

--- a/scm/driver/gitlab/integration/gitlab_test.go
+++ b/scm/driver/gitlab/integration/gitlab_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jenkins-x/go-scm/scm"
 	"github.com/jenkins-x/go-scm/scm/driver/gitlab"
 	"github.com/jenkins-x/go-scm/scm/transport"
 )
@@ -21,8 +22,9 @@ func TestGitLab(t *testing.T) {
 
 	client, _ := gitlab.New("https://gitlab.com/")
 	client.Client = &http.Client{
-		Transport: &transport.PrivateToken{
-			Token: os.Getenv("GITLAB_TOKEN"),
+		Transport: &transport.Auth{
+			Source:     scm.StaticTokenSource(os.Getenv("GITLAB_TOKEN")),
+			Credential: transport.PrivateTokenCredential,
 		},
 	}
 

--- a/scm/factory/factory.go
+++ b/scm/factory/factory.go
@@ -2,7 +2,6 @@ package factory
 
 import (
 	"context"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -21,7 +20,6 @@ import (
 	"github.com/jenkins-x/go-scm/scm/driver/gogs"
 	"github.com/jenkins-x/go-scm/scm/driver/stash"
 	"github.com/jenkins-x/go-scm/scm/transport"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
 
@@ -35,7 +33,7 @@ var DefaultIdentifier = NewDriverIdentifier()
 type ClientOptionFunc func(*scm.Client)
 
 type AuthOptions struct {
-	oauthToken   string
+	tokenSource  scm.TokenSource
 	clientID     string
 	clientSecret string
 }
@@ -77,14 +75,25 @@ func NewClientWithBasicAuth(driver, serverURL, user, password string, opts ...Cl
 
 // NewClient creates a new client for a given driver, serverURL and OAuth token
 func NewClient(driver, serverURL, oauthToken string, opts ...ClientOptionFunc) (*scm.Client, error) {
+	authOptions := &AuthOptions{}
+	if oauthToken != "" {
+		authOptions.tokenSource = scm.StaticTokenSource(oauthToken)
+	}
+	return newClient(driver, serverURL, authOptions, opts...)
+}
+
+// NewClientWithTokenSource creates a new client for a given driver and serverURL that
+// resolves its credential from source on every request, for tokens that expire during
+// the life of the client such as GitHub App installation tokens.
+func NewClientWithTokenSource(driver, serverURL string, source scm.TokenSource, opts ...ClientOptionFunc) (*scm.Client, error) {
 	authOptions := &AuthOptions{
-		oauthToken: oauthToken,
+		tokenSource: source,
 	}
 	return newClient(driver, serverURL, authOptions, opts...)
 }
 
 func newClient(driver, serverURL string, authOptions *AuthOptions, opts ...ClientOptionFunc) (*scm.Client, error) {
-	oauthToken := authOptions.oauthToken
+	source := authOptions.tokenSource
 	if driver == "" {
 		driver = "github"
 	}
@@ -110,7 +119,11 @@ func newClient(driver, serverURL string, authOptions *AuthOptions, opts ...Clien
 		if serverURL == "" {
 			return nil, ErrMissingGitServerURL
 		}
-		client, err = gitea.NewWithToken(serverURL, oauthToken)
+		if source == nil {
+			client, err = gitea.New(serverURL)
+		} else {
+			client, err = gitea.NewWithTokenSource(serverURL, source)
+		}
 	case "github":
 		if serverURL != "" {
 			client, err = github.New(ensureGHEEndpoint(serverURL))
@@ -139,30 +152,11 @@ func newClient(driver, serverURL string, authOptions *AuthOptions, opts ...Clien
 	if err != nil {
 		return client, err
 	}
-	if oauthToken != "" {
+	if source != nil {
 		switch driver {
-		case "azure":
-			client.Client = &http.Client{
-				Transport: &transport.Custom{
-					Before: func(r *http.Request) {
-						encoded := base64.StdEncoding.EncodeToString([]byte(":" + oauthToken))
-						r.Header.Set("Authorization", fmt.Sprintf("Basic %s", encoded))
-					},
-				},
-			}
 		case "gitea":
-			client.Client = &http.Client{
-				Transport: &transport.Authorization{
-					Scheme:      "token",
-					Credentials: oauthToken,
-				},
-			}
-		case "gitlab":
-			client.Client = &http.Client{
-				Transport: &transport.PrivateToken{
-					Token: oauthToken,
-				},
-			}
+			// Authenticated when the client is constructed, because the Gitea
+			// SDK holds an http.Client of its own that also needs the token.
 		case "bitbucketcloud":
 			// lets process any options now so that we can populate the username
 			for _, o := range opts {
@@ -182,23 +176,38 @@ func newClient(driver, serverURL string, authOptions *AuthOptions, opts ...Clien
 			}
 			// BB App Password / PAT
 			client.Client = &http.Client{
-				Transport: &transport.BasicAuth{
-					Username: client.Username,
-					Password: oauthToken,
+				Transport: &transport.Auth{
+					Source:     source,
+					Credential: transport.BasicAuthCredential(client.Username),
 				},
 			}
 			return client, nil
 		default:
-			ts := oauth2.StaticTokenSource(
-				&oauth2.Token{AccessToken: oauthToken},
-			)
-			client.Client = oauth2.NewClient(context.Background(), ts)
+			client.Client = &http.Client{
+				Transport: &transport.Auth{
+					Source:     source,
+					Credential: credentialFor(driver),
+				},
+			}
 		}
 	}
 	for _, o := range opts {
 		o(client)
 	}
 	return client, err
+}
+
+// credentialFor returns how driver expects a token to be attached to a request.
+// A driver missing here falls through to a bearer token, which most accept.
+func credentialFor(driver string) transport.Credential {
+	switch driver {
+	case "azure":
+		return transport.BasicAuthCredential("")
+	case "gitlab":
+		return transport.PrivateTokenCredential
+	default:
+		return transport.SchemeCredential("Bearer")
+	}
 }
 
 // NewClientFromEnvironment creates a new client using environment variables $GIT_KIND, $GIT_SERVER, $GIT_TOKEN
@@ -220,7 +229,7 @@ func NewClientFromEnvironment() (*scm.Client, error) {
 	}
 
 	authOptions := &AuthOptions{
-		oauthToken: oauthToken,
+		tokenSource: scm.StaticTokenSource(oauthToken),
 	}
 
 	clientID := os.Getenv("BB_OAUTH_CLIENT_ID")

--- a/scm/factory/factory_test.go
+++ b/scm/factory/factory_test.go
@@ -49,16 +49,16 @@ func TestFromRepoURL(t *testing.T) {
 	if client.Driver != scm.DriverGitlab {
 		t.Fatalf("Driver got %q, want %q", client.Driver, client.Driver)
 	}
-	assert.Equal(t, "abc123", sentHeader(t, client, "Private-Token"))
+	assert.Equal(t, "abc123", sentRequest(t, client).Header.Get("Private-Token"))
 }
 
-// sentHeader issues a request through the client's transport and returns the
-// value the transport attached, which is the credential the factory installed.
-func sentHeader(t *testing.T, client *scm.Client, header string) string {
+// sentRequest issues a request through the client's transport and returns it as
+// the server saw it, carrying whatever credential the factory installed.
+func sentRequest(t *testing.T, client *scm.Client) *http.Request {
 	t.Helper()
-	var got string
+	var got *http.Request
 	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		got = r.Header.Get(header)
+		got = r
 	}))
 	defer srv.Close()
 
@@ -78,15 +78,25 @@ func TestNewClientWithTokenSource(t *testing.T) {
 		{driver: "gogs", header: "Authorization", want: "Bearer token-1"},
 		{driver: "stash", header: "Authorization", want: "Bearer token-1"},
 		{driver: "gitlab", header: "Private-Token", want: "token-1"},
-		{driver: "azure", header: "Authorization", want: "Basic OnRva2VuLTE="},
 	}
 	for _, tc := range tests {
 		t.Run(tc.driver, func(t *testing.T) {
 			client, err := NewClientWithTokenSource(tc.driver, "https://example.com", &mintingSource{})
 			require.NoError(t, err)
-			assert.Equal(t, tc.want, sentHeader(t, client, tc.header))
+			assert.Equal(t, tc.want, sentRequest(t, client).Header.Get(tc.header))
 		})
 	}
+}
+
+func TestNewClientWithTokenSource_Azure(t *testing.T) {
+	client, err := NewClientWithTokenSource("azure", "https://example.com", &mintingSource{})
+	require.NoError(t, err)
+
+	// Azure DevOps takes the token as the password with no username.
+	username, password, ok := sentRequest(t, client).BasicAuth()
+	require.True(t, ok)
+	assert.Empty(t, username)
+	assert.Equal(t, "token-1", password)
 }
 
 // TestNewClientWithTokenSource_Gitea covers the Gitea SDK's own http.Client as
@@ -117,15 +127,19 @@ func TestNewClientWithTokenSource_Gitea(t *testing.T) {
 func TestNewClientWithTokenSource_BitbucketCloud(t *testing.T) {
 	client, err := NewClientWithTokenSource("bitbucketcloud", "", &mintingSource{}, SetUsername("bot"))
 	require.NoError(t, err)
-	assert.Equal(t, "Basic Ym90OnRva2VuLTE=", sentHeader(t, client, "Authorization"))
+
+	username, password, ok := sentRequest(t, client).BasicAuth()
+	require.True(t, ok)
+	assert.Equal(t, "bot", username)
+	assert.Equal(t, "token-1", password)
 }
 
 func TestNewClientWithTokenSource_RefreshesToken(t *testing.T) {
 	client, err := NewClientWithTokenSource("github", "", &mintingSource{})
 	require.NoError(t, err)
 
-	assert.Equal(t, "Bearer token-1", sentHeader(t, client, "Authorization"))
-	assert.Equal(t, "Bearer token-2", sentHeader(t, client, "Authorization"))
+	assert.Equal(t, "Bearer token-1", sentRequest(t, client).Header.Get("Authorization"))
+	assert.Equal(t, "Bearer token-2", sentRequest(t, client).Header.Get("Authorization"))
 }
 
 // mintingSource issues a different token on each call, standing in for a source

--- a/scm/factory/factory_test.go
+++ b/scm/factory/factory_test.go
@@ -1,12 +1,15 @@
 package factory
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/jenkins-x/go-scm/scm"
-	"github.com/jenkins-x/go-scm/scm/transport"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewClient(t *testing.T) {
@@ -46,7 +49,92 @@ func TestFromRepoURL(t *testing.T) {
 	if client.Driver != scm.DriverGitlab {
 		t.Fatalf("Driver got %q, want %q", client.Driver, client.Driver)
 	}
-	if p := client.Client.Transport.(*transport.PrivateToken).Token; p != "abc123" {
-		t.Fatalf("got %q, want %q", p, "abc123")
+	assert.Equal(t, "abc123", sentHeader(t, client, "Private-Token"))
+}
+
+// sentHeader issues a request through the client's transport and returns the
+// value the transport attached, which is the credential the factory installed.
+func sentHeader(t *testing.T, client *scm.Client, header string) string {
+	t.Helper()
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get(header)
+	}))
+	defer srv.Close()
+
+	res, err := client.Client.Get(srv.URL)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+	return got
+}
+
+func TestNewClientWithTokenSource(t *testing.T) {
+	tests := []struct {
+		driver string
+		header string
+		want   string
+	}{
+		{driver: "github", header: "Authorization", want: "Bearer token-1"},
+		{driver: "gogs", header: "Authorization", want: "Bearer token-1"},
+		{driver: "stash", header: "Authorization", want: "Bearer token-1"},
+		{driver: "gitlab", header: "Private-Token", want: "token-1"},
+		{driver: "azure", header: "Authorization", want: "Basic OnRva2VuLTE="},
 	}
+	for _, tc := range tests {
+		t.Run(tc.driver, func(t *testing.T) {
+			client, err := NewClientWithTokenSource(tc.driver, "https://example.com", &mintingSource{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, sentHeader(t, client, tc.header))
+		})
+	}
+}
+
+// TestNewClientWithTokenSource_Gitea covers the Gitea SDK's own http.Client as
+// well as scm.Client, since the driver serves calls from both.
+func TestNewClientWithTokenSource_Gitea(t *testing.T) {
+	var sdkAuth, clientAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/version" {
+			sdkAuth = r.Header.Get("Authorization")
+			fmt.Fprint(w, `{"version":"1.22.0"}`)
+			return
+		}
+		clientAuth = r.Header.Get("Authorization")
+	}))
+	defer srv.Close()
+
+	client, err := NewClientWithTokenSource("gitea", srv.URL, &mintingSource{})
+	require.NoError(t, err)
+
+	res, err := client.Client.Get(srv.URL)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+
+	assert.Equal(t, "token token-1", sdkAuth)
+	assert.Equal(t, "token token-2", clientAuth)
+}
+
+func TestNewClientWithTokenSource_BitbucketCloud(t *testing.T) {
+	client, err := NewClientWithTokenSource("bitbucketcloud", "", &mintingSource{}, SetUsername("bot"))
+	require.NoError(t, err)
+	assert.Equal(t, "Basic Ym90OnRva2VuLTE=", sentHeader(t, client, "Authorization"))
+}
+
+func TestNewClientWithTokenSource_RefreshesToken(t *testing.T) {
+	client, err := NewClientWithTokenSource("github", "", &mintingSource{})
+	require.NoError(t, err)
+
+	assert.Equal(t, "Bearer token-1", sentHeader(t, client, "Authorization"))
+	assert.Equal(t, "Bearer token-2", sentHeader(t, client, "Authorization"))
+}
+
+// mintingSource issues a different token on each call, standing in for a source
+// of short lived credentials such as GitHub App installation tokens.
+type mintingSource struct {
+	calls int
+}
+
+func (s *mintingSource) Token(context.Context) (*scm.Token, error) {
+	s.calls++
+	return &scm.Token{Token: fmt.Sprintf("token-%d", s.calls)}, nil
 }

--- a/scm/token.go
+++ b/scm/token.go
@@ -32,3 +32,18 @@ type (
 func WithContext(parent context.Context, token *Token) context.Context {
 	return context.WithValue(parent, TokenKey{}, token)
 }
+
+// StaticTokenSource returns a TokenSource that always returns the same token.
+// Because the token is never refreshed it is only suitable for credentials
+// that do not expire, such as a personal access token.
+func StaticTokenSource(token string) TokenSource {
+	return staticTokenSource{token: &Token{Token: token}}
+}
+
+type staticTokenSource struct {
+	token *Token
+}
+
+func (s staticTokenSource) Token(context.Context) (*Token, error) {
+	return s.token, nil
+}

--- a/scm/transport/auth.go
+++ b/scm/transport/auth.go
@@ -9,6 +9,9 @@ import "net/http"
 // Authorization is an http.RoundTripper that makes HTTP
 // requests, wrapping a base RoundTripper and adding an
 // Authorization header with credentials
+//
+// Deprecated: use Auth with SchemeCredential(scheme), which resolves the
+// credential from a scm.TokenSource per request rather than capturing it.
 type Authorization struct {
 	Base http.RoundTripper
 

--- a/scm/transport/basicauth.go
+++ b/scm/transport/basicauth.go
@@ -9,6 +9,9 @@ import "net/http"
 // BasicAuth is an http.RoundTripper that makes HTTP
 // requests, wrapping a base RoundTripper and adding a
 // Basic Authorization header.
+//
+// Deprecated: use Auth with BasicAuthCredential(username), which resolves the
+// password from a scm.TokenSource per request rather than capturing it.
 type BasicAuth struct {
 	Base http.RoundTripper
 

--- a/scm/transport/bearer.go
+++ b/scm/transport/bearer.go
@@ -9,6 +9,9 @@ import "net/http"
 // BearerToken is an http.RoundTripper that makes HTTP
 // requests, wrapping a base RoundTripper and adding an
 // Authorization header with the Bearer Token.
+//
+// Deprecated: use Auth with SchemeCredential("Bearer"), which resolves the
+// token from a scm.TokenSource per request rather than capturing it.
 type BearerToken struct {
 	Base http.RoundTripper
 

--- a/scm/transport/private.go
+++ b/scm/transport/private.go
@@ -9,6 +9,9 @@ import "net/http"
 // PrivateToken is an http.RoundTripper that makes HTTP
 // requests, wrapping a base RoundTripper and adding an
 // Private-Token header with the GitLab personal token.
+//
+// Deprecated: use Auth with PrivateTokenCredential, which resolves the token
+// from a scm.TokenSource per request rather than capturing it.
 type PrivateToken struct {
 	Base http.RoundTripper
 

--- a/scm/transport/tokensource.go
+++ b/scm/transport/tokensource.go
@@ -1,0 +1,67 @@
+package transport
+
+import (
+	"net/http"
+
+	"github.com/jenkins-x/go-scm/scm"
+)
+
+// A Credential attaches a resolved token to a request in whichever form the
+// provider expects.
+type Credential func(r *http.Request, token string)
+
+// Auth is an http.RoundTripper that resolves its credential from a
+// scm.TokenSource on every request rather than capturing it, so a token that
+// expires part way through the life of a client is replaced without the client
+// having to be rebuilt.
+type Auth struct {
+	Base http.RoundTripper
+
+	Source     scm.TokenSource
+	Credential Credential
+}
+
+// RoundTrip resolves a token and attaches it to the request.
+func (t *Auth) RoundTrip(r *http.Request) (*http.Response, error) {
+	token, err := t.Source.Token(r.Context())
+	if err != nil {
+		return nil, err
+	}
+	if token == nil || token.Token == "" {
+		return t.base().RoundTrip(r)
+	}
+	r2 := cloneRequest(r)
+	t.Credential(r2, token.Token)
+	return t.base().RoundTrip(r2)
+}
+
+// base returns the base transport. If no base transport
+// is configured, the default transport is returned.
+func (t *Auth) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+// SchemeCredential returns a Credential that sets an Authorization header with
+// the given scheme, such as "Bearer", or the non-standard "token" scheme that
+// Gogs and Gitea use.
+func SchemeCredential(scheme string) Credential {
+	return func(r *http.Request, token string) {
+		r.Header.Set("Authorization", scheme+" "+token)
+	}
+}
+
+// BasicAuthCredential returns a Credential that sends the token as the basic
+// auth password. Azure DevOps expects an empty username.
+func BasicAuthCredential(username string) Credential {
+	return func(r *http.Request, token string) {
+		r.SetBasicAuth(username, token)
+	}
+}
+
+// PrivateTokenCredential sets the Private-Token header that GitLab expects.
+func PrivateTokenCredential(r *http.Request, token string) {
+	r.Header.Set("Private-Token", token)
+}

--- a/scm/transport/tokensource.go
+++ b/scm/transport/tokensource.go
@@ -1,6 +1,7 @@
 package transport
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -13,7 +14,7 @@ type Credential func(r *http.Request, token string)
 // Auth is an http.RoundTripper that resolves its credential from a
 // scm.TokenSource on every request rather than capturing it, so a token that
 // expires part way through the life of a client is replaced without the client
-// having to be rebuilt.
+// having to be rebuilt. Both Source and Credential are required.
 type Auth struct {
 	Base http.RoundTripper
 
@@ -23,6 +24,9 @@ type Auth struct {
 
 // RoundTrip resolves a token and attaches it to the request.
 func (t *Auth) RoundTrip(r *http.Request) (*http.Response, error) {
+	if t.Source == nil || t.Credential == nil {
+		return nil, errors.New("transport: Auth requires both a Source and a Credential")
+	}
 	token, err := t.Source.Token(r.Context())
 	if err != nil {
 		return nil, err

--- a/scm/transport/tokensource_test.go
+++ b/scm/transport/tokensource_test.go
@@ -75,33 +75,42 @@ func TestAuth_Credentials(t *testing.T) {
 	tests := []struct {
 		name       string
 		credential Credential
-		header     string
-		want       string
+		check      func(t *testing.T, r *http.Request)
 	}{
 		{
 			name:       "scheme",
 			credential: SchemeCredential("token"),
-			header:     "Authorization",
-			want:       "token token-1",
+			check: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "token token-1", r.Header.Get("Authorization"))
+			},
 		},
 		{
 			name:       "private token",
 			credential: PrivateTokenCredential,
-			header:     "Private-Token",
-			want:       "token-1",
+			check: func(t *testing.T, r *http.Request) {
+				assert.Equal(t, "token-1", r.Header.Get("Private-Token"))
+			},
 		},
 		{
 			name:       "basic auth with a username",
 			credential: BasicAuthCredential("bot"),
-			header:     "Authorization",
-			want:       "Basic Ym90OnRva2VuLTE=",
+			check: func(t *testing.T, r *http.Request) {
+				username, password, ok := r.BasicAuth()
+				require.True(t, ok)
+				assert.Equal(t, "bot", username)
+				assert.Equal(t, "token-1", password)
+			},
 		},
 		{
 			// Azure DevOps sends the token as the password with no username.
 			name:       "basic auth without a username",
 			credential: BasicAuthCredential(""),
-			header:     "Authorization",
-			want:       "Basic OnRva2VuLTE=",
+			check: func(t *testing.T, r *http.Request) {
+				username, password, ok := r.BasicAuth()
+				require.True(t, ok)
+				assert.Empty(t, username)
+				assert.Equal(t, "token-1", password)
+			},
 		},
 	}
 	for _, tc := range tests {
@@ -115,7 +124,7 @@ func TestAuth_Credentials(t *testing.T) {
 			get(t, client, srv.URL)
 
 			require.Len(t, requests, 1)
-			assert.Equal(t, tc.want, requests[0].Header.Get(tc.header))
+			tc.check(t, requests[0])
 		})
 	}
 }

--- a/scm/transport/tokensource_test.go
+++ b/scm/transport/tokensource_test.go
@@ -141,6 +141,23 @@ func TestAuth_SourceError(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot mint a token")
 }
 
+func TestAuth_Misconfigured(t *testing.T) {
+	tests := map[string]*Auth{
+		"no source":     {Credential: SchemeCredential("Bearer")},
+		"no credential": {Source: &mintingSource{}},
+		"neither":       {},
+	}
+	for name, tr := range tests {
+		t.Run(name, func(t *testing.T) {
+			//nolint:bodyclose // the transport fails before a response exists
+			res, err := (&http.Client{Transport: tr}).Get("http://localhost")
+			require.Nil(t, res)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "requires both a Source and a Credential")
+		})
+	}
+}
+
 func TestAuth_NoTokenSendsRequestUnauthenticated(t *testing.T) {
 	var requests []*http.Request
 	srv := recorder(t, &requests)

--- a/scm/transport/tokensource_test.go
+++ b/scm/transport/tokensource_test.go
@@ -1,0 +1,165 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jenkins-x/go-scm/scm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mintingSource issues a different token on each call, standing in for a source
+// of short lived credentials such as GitHub App installation tokens.
+type mintingSource struct {
+	calls int
+}
+
+func (s *mintingSource) Token(context.Context) (*scm.Token, error) {
+	s.calls++
+	return &scm.Token{Token: fmt.Sprintf("token-%d", s.calls)}, nil
+}
+
+type errorSource struct{}
+
+func (errorSource) Token(context.Context) (*scm.Token, error) {
+	return nil, errors.New("cannot mint a token")
+}
+
+type nilSource struct{}
+
+func (nilSource) Token(context.Context) (*scm.Token, error) {
+	return nil, nil
+}
+
+// recorder captures the requests a transport actually sends.
+func recorder(t *testing.T, requests *[]*http.Request) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		*requests = append(*requests, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func get(t *testing.T, client *http.Client, url string) {
+	t.Helper()
+	res, err := client.Get(url)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+}
+
+func TestAuth_ResolvesTokenOnEveryRequest(t *testing.T) {
+	var requests []*http.Request
+	srv := recorder(t, &requests)
+
+	client := &http.Client{
+		Transport: &Auth{
+			Source:     &mintingSource{},
+			Credential: SchemeCredential("Bearer"),
+		},
+	}
+	get(t, client, srv.URL)
+	get(t, client, srv.URL)
+
+	require.Len(t, requests, 2)
+	assert.Equal(t, "Bearer token-1", requests[0].Header.Get("Authorization"))
+	assert.Equal(t, "Bearer token-2", requests[1].Header.Get("Authorization"))
+}
+
+func TestAuth_Credentials(t *testing.T) {
+	tests := []struct {
+		name       string
+		credential Credential
+		header     string
+		want       string
+	}{
+		{
+			name:       "scheme",
+			credential: SchemeCredential("token"),
+			header:     "Authorization",
+			want:       "token token-1",
+		},
+		{
+			name:       "private token",
+			credential: PrivateTokenCredential,
+			header:     "Private-Token",
+			want:       "token-1",
+		},
+		{
+			name:       "basic auth with a username",
+			credential: BasicAuthCredential("bot"),
+			header:     "Authorization",
+			want:       "Basic Ym90OnRva2VuLTE=",
+		},
+		{
+			// Azure DevOps sends the token as the password with no username.
+			name:       "basic auth without a username",
+			credential: BasicAuthCredential(""),
+			header:     "Authorization",
+			want:       "Basic OnRva2VuLTE=",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var requests []*http.Request
+			srv := recorder(t, &requests)
+
+			client := &http.Client{
+				Transport: &Auth{Source: &mintingSource{}, Credential: tc.credential},
+			}
+			get(t, client, srv.URL)
+
+			require.Len(t, requests, 1)
+			assert.Equal(t, tc.want, requests[0].Header.Get(tc.header))
+		})
+	}
+}
+
+func TestAuth_SourceError(t *testing.T) {
+	client := &http.Client{
+		Transport: &Auth{Source: errorSource{}, Credential: SchemeCredential("Bearer")},
+	}
+
+	//nolint:bodyclose // the transport fails before a response exists
+	res, err := client.Get("http://localhost")
+	require.Nil(t, res)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot mint a token")
+}
+
+func TestAuth_NoTokenSendsRequestUnauthenticated(t *testing.T) {
+	var requests []*http.Request
+	srv := recorder(t, &requests)
+
+	client := &http.Client{
+		Transport: &Auth{Source: nilSource{}, Credential: SchemeCredential("Bearer")},
+	}
+	get(t, client, srv.URL)
+
+	require.Len(t, requests, 1)
+	assert.Empty(t, requests[0].Header.Get("Authorization"))
+}
+
+func TestAuth_DoesNotMutateRequest(t *testing.T) {
+	var requests []*http.Request
+	srv := recorder(t, &requests)
+
+	client := &http.Client{
+		Transport: &Auth{Source: &mintingSource{}, Credential: SchemeCredential("Bearer")},
+	}
+	req, err := http.NewRequest("GET", srv.URL, http.NoBody)
+	require.NoError(t, err)
+
+	res, err := client.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, res.Body.Close())
+
+	assert.Empty(t, req.Header.Get("Authorization"))
+	require.Len(t, requests, 1)
+	assert.Equal(t, "Bearer token-1", requests[0].Header.Get("Authorization"))
+}


### PR DESCRIPTION
### Changes
- Add `scm.TokenSource` based auth: `transport.Auth` resolves the credential per
  request instead of capturing it at construction
- Expose `factory.NewClientWithTokenSource()`: rewire `AuthOptions` to hold a
  `scm.TokenSource` rather than a raw token string
- Add `scm.StaticTokenSource()` so `NewClient()` keeps its existing behaviour
- Add `gitea.NewWithTokenSource()`: consolidate the Gitea constructors
- Add deprecation notices to the existing transports: These do not support dynamic tokens

### Context
Looking at proper GitHub App support within lighthouse so we can use the extended
rate limit.

Currently all of jx kinda assumes a static token, one that never refreshes such as a PAT. When running as an app the token is refreshed periodically, so we need a way of passing in a token source that can refresh the token part way through the client's life cycle.

To do this I've rewired the factory options to use the TokenSource and exposed a `NewClientWithTokenSource()` so that the caller can pass their own source in. The existing interface of `NewClient()` is untouched, though it now resolves to a static source internally.

Since the static transports can't refresh at all, I've marked them deprecated. I can remove them as the functionality is replicated but I'm not 100% sure who uses this.