### PR TITLE
Allow Parent to status input for bitbucket data center

### DIFF
--- a/scm/driver/stash/repo.go
+++ b/scm/driver/stash/repo.go
@@ -78,11 +78,12 @@ type hookInput struct {
 }
 
 type status struct {
-	State string `json:"state"`
-	Key   string `json:"key"`
-	Name  string `json:"name"`
-	URL   string `json:"url"`
-	Desc  string `json:"description"`
+	State  string `json:"state"`
+	Key    string `json:"key"`
+	Name   string `json:"name"`
+	URL    string `json:"url"`
+	Parent string `json:"parent,omitempty"`
+	Desc   string `json:"description"`
 }
 
 type statuses struct {
@@ -469,15 +470,29 @@ func (s *repositoryService) UpdateHook(ctx context.Context, repo string, input *
 }
 
 // CreateStatus creates a new commit status.
-// reference: https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/
+// reference (EOL Server): https://developer.atlassian.com/server/bitbucket/how-tos/updating-build-status-for-commits/
+// reference (Data Center): https://developer.atlassian.com/server/bitbucket/rest/v1004/api-group-builds-and-deployments/#api-api-latest-projects-projectkey-repos-repositoryslug-commits-commitid-builds-post
 func (s *repositoryService) CreateStatus(ctx context.Context, repo, ref string, input *scm.StatusInput) (*scm.Status, *scm.Response, error) {
 	path := fmt.Sprintf("rest/build-status/1.0/commits/%s", url.PathEscape(ref))
+	key := input.Label
+	if input.Parent != "" {
+		// bitbucket dc required builds only works if key format is: <parent>/<label>
+		key = fmt.Sprintf("%s/%s", input.Parent, input.Label)
+		projectKey, repositorySlug := scm.Split(repo)
+		path = fmt.Sprintf(
+			"rest/api/latest/projects/%s/repos/%s/commits/%s/builds",
+			url.PathEscape(projectKey),
+			url.PathEscape(repositorySlug),
+			url.PathEscape(ref),
+		)
+	}
 	in := status{
-		State: convertFromState(input.State),
-		Key:   input.Label,
-		Name:  input.Label,
-		URL:   input.Link,
-		Desc:  input.Desc,
+		State:  convertFromState(input.State),
+		Key:    key,
+		Name:   input.Label,
+		URL:    input.Link,
+		Parent: input.Parent,
+		Desc:   input.Desc,
 	}
 	res, err := s.client.do(ctx, "POST", path, in, nil)
 	return &scm.Status{

--- a/scm/driver/stash/repo_test.go
+++ b/scm/driver/stash/repo_test.go
@@ -7,6 +7,7 @@ package stash
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"testing"
 
@@ -421,11 +422,84 @@ func TestRepositoryService_FindCombinedStatus(t *testing.T) {
 	}
 }
 
-func TestStatusCreate(t *testing.T) {
+func TestStatusCreateWithParent(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com:7990").
+		Post("/rest/api/latest/projects/PRJ/repos/my-repo/commits/a6e5e7d797edf751cbd839d6bd4aef86c941eec9/builds").
+		JSON(status{
+			State:  "SUCCESSFUL",
+			Key:    "build-parent/continuous-integration/drone/pull",
+			Name:   "continuous-integration/drone/pull",
+			URL:    "https://ci.example.com/1000/output",
+			Parent: "build-parent",
+			Desc:   "Build has completed successfully",
+		}).
+		Reply(204)
+
+	in := &scm.StatusInput{
+		Desc:   "Build has completed successfully",
+		Label:  "continuous-integration/drone/pull",
+		State:  scm.StateSuccess,
+		Link:   "https://ci.example.com/1000/output",
+		Parent: "build-parent",
+	}
+
+	client, _ := New("http://example.com:7990")
+	_, _, err := client.Repositories.CreateStatus(context.Background(), "PRJ/my-repo", "a6e5e7d797edf751cbd839d6bd4aef86c941eec9", in)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
+func TestStatusCreateWithParentEscapedRepository(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("http://example.com:7990").
+		Post("/rest/api/latest/projects/PRJ+special/repos/repo%2Fwith+chars/commits/a6e5e7d797edf751cbd839d6bd4aef86c941eec9/builds").
+		Map(func(req *http.Request) *http.Request {
+			req.URL.Path = req.URL.Opaque
+			return req
+		}).
+		JSON(status{
+			State:  "SUCCESSFUL",
+			Key:    "build-parent/continuous-integration/drone/pull",
+			Name:   "continuous-integration/drone/pull",
+			URL:    "https://ci.example.com/1000/output",
+			Parent: "build-parent",
+			Desc:   "Build has completed successfully",
+		}).
+		Reply(204)
+
+	in := &scm.StatusInput{
+		Desc:   "Build has completed successfully",
+		Label:  "continuous-integration/drone/pull",
+		State:  scm.StateSuccess,
+		Link:   "https://ci.example.com/1000/output",
+		Parent: "build-parent",
+	}
+
+	client, _ := New("http://example.com:7990")
+	_, _, err := client.Repositories.CreateStatus(context.Background(), "PRJ+special/repo/with+chars", "a6e5e7d797edf751cbd839d6bd4aef86c941eec9", in)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
+func TestStatusCreateWithoutParent(t *testing.T) {
 	defer gock.Off()
 
 	gock.New("http://example.com:7990").
 		Post("/rest/build-status/1.0/commits/a6e5e7d797edf751cbd839d6bd4aef86c941eec9").
+		JSON(status{
+			State: "SUCCESSFUL",
+			Key:   "continuous-integration/drone/pull",
+			Name:  "continuous-integration/drone/pull",
+			URL:   "https://ci.example.com/1000/output",
+			Desc:  "Build has completed successfully",
+		}).
 		Reply(204)
 
 	in := &scm.StatusInput{

--- a/scm/repo.go
+++ b/scm/repo.go
@@ -120,6 +120,7 @@ type (
 		Desc   string
 		Target string
 		Link   string
+		Parent string
 	}
 
 	// DeployStatus represents a deployment status.


### PR DESCRIPTION
## Summary
This PR adds support for an explicit Parent field in scm.StatusInput and propagates it through the Stash / Bitbucket Server driver when creating build statuses.

Bitbucket Server supports grouping build statuses using a parent attribute, which is required for features such as required builds. Prior to this change, go-scm did not expose a first-class way for callers to provide this information, preventing consumers from accurately representing Bitbucket build status hierarchies.

## Related Issue
Closes #540 
